### PR TITLE
Fix rift storage and soulbound items in the End

### DIFF
--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -46,6 +46,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.stats.AchievementList;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -56,6 +57,7 @@ import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.event.entity.player.AchievementEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
@@ -176,6 +178,14 @@ public class AMEventHandler{
 
 		if (soonToBeDead instanceof EntityVillager && ((EntityVillager)soonToBeDead).isChild()){
 			BossSpawnHelper.instance.onVillagerChildKilled((EntityVillager)soonToBeDead);
+		}
+	}
+
+	@SubscribeEvent
+	public void onPlayerGetAchievement(AchievementEvent event){
+		if (!event.entityPlayer.worldObj.isRemote && event.achievement == AchievementList.theEnd2){
+			AMCore.instance.proxy.playerTracker.storeExtendedPropertiesForRespawn(event.entityPlayer);
+			// AMCore.instance.proxy.playerTracker.storeSoulboundItemsForRespawn(event.entityPlayer);
 		}
 	}
 
@@ -315,14 +325,6 @@ public class AMEventHandler{
 	public void onEntityLiving(LivingUpdateEvent event){
 
 		EntityLivingBase ent = event.entityLiving;
-
-		if (ent.isDead){
-			if (ent instanceof EntityPlayer && ent.dimension == 1){
-				AMCore.instance.proxy.playerTracker.storeExtendedPropertiesForRespawn((EntityPlayer)ent);
-				AMCore.instance.proxy.playerTracker.storeSoulboundItemsForRespawn((EntityPlayer)ent);
-			}
-			return;
-		}
 
 		World world = ent.worldObj;
 


### PR DESCRIPTION
This is a fix for issue #1096 (rift storage not synchronising when in the End), and possibly for soulbound items not being saved (issue #1209 - I forget whether it was already solved when I started banging away at the newly-released source...). Because Mojang are weird, they hardcoded End portals to always send you to dimension 1 regardless of where you are, and then put in a special case test to see if you're going from 1 to 1.

This special case test doesn't fire a dimension transfer event, so the extended properties (rift storage, magic levels, etc.) never get saved and you lose everything when the game creates you anew.

What does trigger, however, is an achievement - which does have an event of its own. I hook that and use it to save the extended properties data (but not the soulbound items data - the game somehow seems to know what your inventory is and if you run the soulbound items save, you actually lose them when you respawn). This seems to keep the rift storage consistent when leaving the End, regardless of whether you died or stepped into the portal.

I've also deleted a special case check in the LivingUpdateEvent towards the end, where it sees whether you died in the End and runs the save manually. I suspect that this was what caused the loss of soulbound items previously - the onDeath check ran normally, moved your items into its special stash, and then the special check ran, saw that you had no items and dutifully cleared your soulbound storage (or the events could have fired the other way around, I don't know). While this may not have been the root cause of the soulbound end issue, deleting these few lines of code caused no apparent damage and so I can advocate removing this little special case check purely from a cleanliness perspective.