### PR TITLE
Re-fix issue #1178, remove sneaking requirement to open essence bag

### DIFF
--- a/src/main/java/am2/items/ItemEssenceBag.java
+++ b/src/main/java/am2/items/ItemEssenceBag.java
@@ -35,9 +35,7 @@ public class ItemEssenceBag extends ArsMagicaItem{
 
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer entityplayer){
-		if (entityplayer.isSneaking()){
-			FMLNetworkHandler.openGui(entityplayer, AMCore.instance, ArsMagicaGuiIdList.GUI_ESSENCE_BAG, world, (int)entityplayer.posX, (int)entityplayer.posY, (int)entityplayer.posZ);
-		}
+		FMLNetworkHandler.openGui(entityplayer, AMCore.instance, ArsMagicaGuiIdList.GUI_ESSENCE_BAG, world, (int)entityplayer.posX, (int)entityplayer.posY, (int)entityplayer.posZ);
 		return stack;
 	}
 
@@ -57,8 +55,7 @@ public class ItemEssenceBag extends ArsMagicaItem{
 				continue;
 			}else{
 				itemStack.stackTagCompound.setInteger("essencebagstacksize" + i, stack.stackSize);
-				if (stack.getItemDamage() != 0)
-					itemStack.stackTagCompound.setInteger("essencebagmeta" + i, stack.getItemDamage());
+				itemStack.stackTagCompound.setInteger("essencebagmeta" + i, stack.getItemDamage());
 			}
 		}
 	}
@@ -73,8 +70,7 @@ public class ItemEssenceBag extends ArsMagicaItem{
 				continue;
 			}else{
 				itemStack.stackTagCompound.setInteger("essencebagstacksize" + i, stack.stackSize);
-				if (stack.getItemDamage() != 0)
-					itemStack.stackTagCompound.setInteger("essencebagmeta" + i, stack.getItemDamage());
+				itemStack.stackTagCompound.setInteger("essencebagmeta" + i, stack.getItemDamage());
 			}
 		}
 	}


### PR DESCRIPTION
Issue #1178 (arcane essences are erased by the essence bag) was marked as fixed during dev, but I'm assuming that it's one of the things that was lost since the issue appears to be present in the released source. I've fixed it here by removing the metadata == 0 check and forcing it to always save the metadata - this appears to have solved the problem.

There was also a part of the code at the beginning of the file which required the user to be sneaking in order to open the bag. I don't like this behaviour - it's inconsistent with all other personal inventory items, so I removed it. This is not related to the bugfix and is a preference of mine.
