### PR TITLE
Re-fix issue #1085

### DIFF
--- a/src/main/java/am2/blocks/BlockKeystoneDoor.java
+++ b/src/main/java/am2/blocks/BlockKeystoneDoor.java
@@ -1,9 +1,11 @@
 package am2.blocks;
 
+import java.util.Random;
 import am2.AMCore;
 import am2.api.blocks.IKeystoneLockable;
 import am2.blocks.tileentities.TileEntityKeystoneDoor;
 import am2.guis.ArsMagicaGuiIdList;
+import am2.items.ItemsCommonProxy;
 import am2.lore.CompendiumUnlockHandler;
 import am2.texture.ResourceManager;
 import am2.utility.KeystoneUtilities;
@@ -16,6 +18,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.IconFlipped;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
@@ -172,6 +175,13 @@ public class BlockKeystoneDoor extends BlockDoor implements ITileEntityProvider{
 			return;
 		super.onBlockHarvested(world, x, y, z, meta, player);
 	}
+	
+	@Override
+	public Item getItemDropped(int p_149650_1_, Random p_149650_2_, int p_149650_3_)
+	{
+	  return ItemsCommonProxy.itemKeystoneDoor;
+	}
+	
 
 	@Override
 	public TileEntity createNewTileEntity(World world, int i){


### PR DESCRIPTION
Issue #1085 (keystone doors drop wooden doors) was marked as fixed during dev, but I'm assuming that this was some of the work which was lost. I've re-fixed that by adding the same override code which vanilla wooden doors have, altered to drop keystone door items.