### PR TITLE
Fix for issue #1199

### DIFF
--- a/src/main/java/am2/blocks/tileentities/TileEntityArcaneDeconstructor.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityArcaneDeconstructor.java
@@ -96,8 +96,10 @@ public class TileEntityArcaneDeconstructor extends TileEntityAMPower implements 
 							}
 						}else{
 							if (current_deconstruction_time++ >= DECONSTRUCTION_TIME){
-								for (ItemStack stack : deconstructionRecipe){
-									transferOrEjectItem(stack);
+							        if(getDeconstructionRecipe() == true){
+									for (ItemStack stack : deconstructionRecipe){
+										transferOrEjectItem(stack);
+									}
 								}
 								deconstructionRecipe = null;
 								decrStackSize(0, 1);
@@ -200,7 +202,7 @@ public class TileEntityArcaneDeconstructor extends TileEntityAMPower implements 
 
 				for (Object o : recipeParts){
 					ItemStack stack = objectToItemStack(o);
-					if (stack != null){
+					if (stack != null && !stack.getItem().hasContainerItem(stack)){
 						stack.stackSize = 1;
 						recipeItems.add(stack.copy());
 					}


### PR DESCRIPTION
This fixes issue #1199 (dupe bug with the arcane deconstructor) by implementing exactly what @raymondhardy suggested in his bug report - an additional check for the item's recipe just before completion. Items without a recipe (such as his example of sticks) get destroyed.

One additional change is that container items are no longer returned - this was from testing out fixes for issue #1029 (magician's workbench bucket duplication), cutting off a potential duplication bug in the process (to test, put cake in the arcane deconstructor). This means that you will lose the milk, water, resonant ender or any other such fluids used to craft an item, but I'm not particularly bothered about a less than 100% return on something you were never able to do in the first place.