### PR TITLE
Fixes issue #1029

### DIFF
--- a/src/main/java/am2/containers/slots/SlotMagiciansWorkbenchCrafting.java
+++ b/src/main/java/am2/containers/slots/SlotMagiciansWorkbenchCrafting.java
@@ -141,17 +141,13 @@ public class SlotMagiciansWorkbenchCrafting extends Slot{
 				MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(thePlayer, itemstack2));
 				itemstack2 = null;
 			}
-
-			if (itemstack2 != null && (itemstack1.getItem().doesContainerItemLeaveCraftingGrid(itemstack1))){
-				if (inventory.getStackInSlot(i) == null){
-					inventory.setInventorySlotContents(i, itemstack2);
-				}else{
-					if (itemstack1.getItem().doesContainerItemLeaveCraftingGrid(itemstack1)){
-						if (!this.thePlayer.inventory.addItemStackToInventory(itemstack2))
-							this.thePlayer.dropItem(itemstack2.getItem(), itemstack2.getItemDamage());
-					}
-				}
+			
+			if (itemstack2 != null){
+			        inventory.setInventorySlotContents(i, itemstack2);
+			}else{
+			        inventory.decrStackSize(i, 1);
 			}
+			
 		}else{
 			inventory.decrStackSize(i, 1);
 		}


### PR DESCRIPTION
This is a fix for issue #1029 (bucket duplication in the magician's workbench), which was readily reproducible when making cake on the first source release. My fix was to remove the check about whether container items should stay in the inventory and to just replace them where they sit - duplicate buckets are therefore not stuffed into the player's inventory and mass is conserved.

A perfect fix would move the excess container items to the workbench's inventory, the players inventory or the space under the player's nose if both are full, and I can see a way to implement that, but I'll have to come back to that when I get more time after looking at the rest of the bugs.