### PR TITLE
Fix for issue #1131 (warding candle crash on redstone ore)

### DIFF
--- a/src/main/java/am2/items/ItemCandle.java
+++ b/src/main/java/am2/items/ItemCandle.java
@@ -55,7 +55,7 @@ public class ItemCandle extends ArsMagicaItem{
 		if (!world.isRemote){
 
 			if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("search_block")){
-				player.addChatMessage(new ChatComponentText("am2.tooltip.candlecantplace"));
+			  player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("am2.tooltip.candlecantplace")));
 				return false;
 			}
 
@@ -170,7 +170,14 @@ public class ItemCandle extends ArsMagicaItem{
 	public String getItemStackDisplayName(ItemStack stack){
 		String name = StatCollector.translateToLocal("item.arsmagica2:warding_candle.name");
 		if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("search_block")){
-			name += " (" + StatCollector.translateToLocal("am2.tooltip.attuned") + ")";
+			ItemStack blockStack = new ItemStack(Block.getBlockById(stack.stackTagCompound.getInteger("search_block")), 1, stack.stackTagCompound.getInteger("search_meta"));
+			Item tempItem = blockStack.getItem();
+			if(tempItem == null){
+				name += " (" + stack.stackTagCompound.getInteger("search_block") + ":" + stack.stackTagCompound.getInteger("search_meta") + ")";
+			}
+			else{
+				name += " (" + blockStack.getDisplayName() + ")";
+			}
 		}else{
 			name += " (" + StatCollector.translateToLocal("am2.tooltip.unattuned") + ")";
 		}

--- a/src/main/java/am2/items/ItemCandle.java
+++ b/src/main/java/am2/items/ItemCandle.java
@@ -55,7 +55,7 @@ public class ItemCandle extends ArsMagicaItem{
 		if (!world.isRemote){
 
 			if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("search_block")){
-			  player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("am2.tooltip.candlecantplace")));
+				player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("am2.tooltip.candlecantplace")));
 				return false;
 			}
 

--- a/src/main/java/am2/items/ItemCandle.java
+++ b/src/main/java/am2/items/ItemCandle.java
@@ -170,8 +170,7 @@ public class ItemCandle extends ArsMagicaItem{
 	public String getItemStackDisplayName(ItemStack stack){
 		String name = StatCollector.translateToLocal("item.arsmagica2:warding_candle.name");
 		if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("search_block")){
-			ItemStack blockStack = new ItemStack(Block.getBlockById(stack.stackTagCompound.getInteger("search_block")), 1, stack.stackTagCompound.getInteger("search_meta"));
-			name += " (" + blockStack.getDisplayName() + ")";
+			name += " (" + StatCollector.translateToLocal("am2.tooltip.unattuned") + ")";
 		}else{
 			name += " (" + StatCollector.translateToLocal("am2.tooltip.unattuned") + ")";
 		}

--- a/src/main/java/am2/items/ItemCandle.java
+++ b/src/main/java/am2/items/ItemCandle.java
@@ -170,7 +170,7 @@ public class ItemCandle extends ArsMagicaItem{
 	public String getItemStackDisplayName(ItemStack stack){
 		String name = StatCollector.translateToLocal("item.arsmagica2:warding_candle.name");
 		if (stack.hasTagCompound() && stack.stackTagCompound.hasKey("search_block")){
-			name += " (" + StatCollector.translateToLocal("am2.tooltip.unattuned") + ")";
+			name += " (" + StatCollector.translateToLocal("am2.tooltip.attuned") + ")";
 		}else{
 			name += " (" + StatCollector.translateToLocal("am2.tooltip.unattuned") + ")";
 		}

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -433,6 +433,7 @@ am2.tooltip.ender_boots=§3I reject your reality, and substitute my own!§f
 am2.tooltip.life_ward=§3Gray Walker, be gone from this place.§f
 am2.tooltip.life_ward2=§3You have no power here!§f
 am2.tooltip.lightning_charm=§3Side effects include muscle spasms and frizzy hair.§f
+am2.tooltip.attuned=Attuned
 am2.tooltip.unattuned=Unattuned
 am2.tooltip.candlecantplace=You cannot place an attuned candle.
 am2.tooltip.success=Pairing Successful!

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -433,7 +433,6 @@ am2.tooltip.ender_boots=§3I reject your reality, and substitute my own!§f
 am2.tooltip.life_ward=§3Gray Walker, be gone from this place.§f
 am2.tooltip.life_ward2=§3You have no power here!§f
 am2.tooltip.lightning_charm=§3Side effects include muscle spasms and frizzy hair.§f
-am2.tooltip.attuned=Attuned
 am2.tooltip.unattuned=Unattuned
 am2.tooltip.candlecantplace=You cannot place an attuned candle.
 am2.tooltip.success=Pairing Successful!


### PR DESCRIPTION
I was able to very reliably reproduce issue #1131 in the initial source release (get warding candle, right-click on iron/gold ores, works fine; right-click on redstone ore and it breaks horribly). My issue here was that the final null pointer was in Mojang's code:
```
java.lang.NullPointerException
at net.minecraft.item.ItemStack.getDisplayName(ItemStack.java:427) ~[ItemStack.class:?]
at am2.items.ItemCandle.getItemStackDisplayName(ItemCandle.java:174) ~[ItemCandle.class:?]
```
Because of this, adding an effective null check (I tried it, it didn't work) would involve either duplicating whatever it is that ItemStack is doing, but with more null checks, or by completely changing the warding candle code to use block names (eg: minecraft:lit_redstone_ore) and then trying to get a localised name for them instead of raw block IDs - both of which invoive a fair bit of effort.

My fix was to just remove the name display and therefore any potential null pointer errors - it now simply says "attuned". This reliably solves the crashes, but it is a fair loss of functionality when compared to the other pull requests I've made and the result may not be up to your standards. It's your call.