### PR TITLE
Automatic allocation (kinda) for potion IDs, allows configuration of mana potion ID

### DIFF
--- a/src/main/java/am2/buffs/BuffList.java
+++ b/src/main/java/am2/buffs/BuffList.java
@@ -87,6 +87,19 @@ public class BuffList implements IBuffHelper{
 		return potion;
 	}
 
+	private static ManaPotion createManaPotion(int index, String name, int IIconRow, int iconCol, boolean isBadEffect, int colour){
+		String configID = name.replace(" ", "").toLowerCase().trim();
+		index = AMCore.config.getConfigurablePotionID(configID, index);
+		
+		FMLLog.info("Ars Magica 2 >> Potion %s is ID %d", name, index);
+		
+		ManaPotion potion = new ManaPotion(index, isBadEffect, colour);
+		potion.setPotionName(name);
+		potion._setIconIndex(iconCol, IIconRow);
+		
+		return potion;
+	}
+
 	private static void createDummyBuff(Class buffEffectClass, int potionID){
 		try{
 			Constructor ctor = buffEffectClass.getConstructor(Integer.TYPE, Integer.TYPE);
@@ -141,18 +154,21 @@ public class BuffList implements IBuffHelper{
 		fury = createAMPotion(potionDefaultOffset + 21, "Fury", 1, 6, false, BuffEffectFury.class);
 		scrambleSynapses = createAMPotion(potionDefaultOffset + 22, "Scramble Synapses", 1, 7, true, BuffEffectScrambleSynapses.class);
 		illumination = createAMPotion(potionDefaultOffset + 23, "Illuminated", 1, 0, false, BuffEffectIllumination.class);
+		
+		greaterManaPotion = createManaPotion(potionDefaultOffset + 24, "Greater Mana Restoration", 0, 1, false, 0x40c6be);
+		// greaterManaPotion = new ManaPotion(potionDefaultOffset + 24, false, 0x40c6be);
+		// greaterManaPotion.setPotionName("Greater Mana Restoration");
+		// greaterManaPotion._setIconIndex(0, 1);
 
-		greaterManaPotion = new ManaPotion(potionDefaultOffset + 24, false, 0x40c6be);
-		greaterManaPotion.setPotionName("Greater Mana Restoration");
-		greaterManaPotion._setIconIndex(0, 1);
+		epicManaPotion = createManaPotion(potionDefaultOffset + 25, "Epic Mana Restoration", 0, 1, false, 0xFF00FF);
+		// epicManaPotion = new ManaPotion(potionDefaultOffset + 25, false, 0xFF00FF);
+		// epicManaPotion.setPotionName("Epic Mana Restoration");
+		// epicManaPotion._setIconIndex(0, 1);
 
-		epicManaPotion = new ManaPotion(potionDefaultOffset + 25, false, 0xFF00FF);
-		epicManaPotion.setPotionName("Epic Mana Restoration");
-		epicManaPotion._setIconIndex(0, 1);
-
-		legendaryManaPotion = new ManaPotion(potionDefaultOffset + 26, false, 0xFFFF00);
-		legendaryManaPotion.setPotionName("Legendary Mana Restoration");
-		legendaryManaPotion._setIconIndex(0, 1);
+		legendaryManaPotion = createManaPotion(potionDefaultOffset + 26, "Legendary Mana Restoration", 0, 1, false, 0xFFFF00);
+		// legendaryManaPotion = new ManaPotion(potionDefaultOffset + 26, false, 0xFFFF00);
+		// legendaryManaPotion.setPotionName("Legendary Mana Restoration");
+		// legendaryManaPotion._setIconIndex(0, 1);
 
 		gravityWell = createAMPotion(potionDefaultOffset + 27, "Gravity Well", 0, 6, true, BuffEffectGravityWell.class);
 		levitation = createAMPotion(potionDefaultOffset + 28, "Levitation", 0, 7, false, BuffEffectLevitation.class);

--- a/src/main/java/am2/configuration/AMConfig.java
+++ b/src/main/java/am2/configuration/AMConfig.java
@@ -6,6 +6,7 @@ import am2.particles.ParticleController;
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.Loader;
 import net.minecraft.client.Minecraft;
+import net.minecraft.potion.Potion;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 
@@ -768,9 +769,30 @@ public class AMConfig extends Configuration{
 		return Math.max(prop.getInt(4), 0);
 	}
 
+	// Gets the first available potion ID
+	// returns -1 if there are no available IDs
+	private static int getNextFreePotionID(){
+		int freeID = -1;
+		for(int i = 1; i < Potion.potionTypes.length; i++){
+			if(Potion.potionTypes[i] == null){
+			  freeID = i;
+			  break;
+			}
+		}
+		return freeID;
+	}
+
 	public int getConfigurablePotionID(String id, int default_value){
-		Property prop = get(CATEGORY_POTIONS, id, default_value);
-		int val = prop.getInt(default_value);
+		// because we auto-configure, default_value is ignored
+		int val = getNextFreePotionID();
+		
+		if(val == -1 && !hasKey(CATEGORY_POTIONS, id)){
+		      FMLLog.severe("Ars Magica >> Cannot find a free potion ID for the %s effect. This will cause severe problems!", id);
+		      FMLLog.severe("Effect %s has been assigned to a default of potion ID 1 (movement speed). Erroneous behaviour *will* result.", id);
+		      val = 1;
+		}
+		Property prop = get(CATEGORY_POTIONS, id, val);
+		val = prop.getInt(val);
 		save();
 		return val;
 	}

--- a/src/main/java/am2/proxy/CommonProxy.java
+++ b/src/main/java/am2/proxy/CommonProxy.java
@@ -88,6 +88,8 @@ public class CommonProxy{
 		blocks.setupSpellConstraints();
 		items.postInit();
 		playerTracker.postInit();
+		
+		BuffList.postInit();
 
 		MinecraftForge.EVENT_BUS.register(new AMEventHandler());
 		MinecraftForge.EVENT_BUS.register(PowerNodeCache.instance);


### PR DESCRIPTION
While testing AM2 in my full modpack, I noticed that the mana potions seemed to have a hard-coded ID and could not be changed through the config file. This caused the game to not start when DragonAPI detected a potion clash with a debuff from RotaryCraft, threw an error to tell me what was going on and (rightfully) halted execution.

The cause was mana potions not being created the same way as other buffs - instead of using the createAMPotion() function which searches the config file for a potion ID, it just created a new potion directly using a hardcoded index. I've added a function to BuffList.java for mana potions which replicates the functionality of createAMPotion(), which means that the mana potions now have config file entries.

This is the main purpose of the pull request.

The secondary addition is as follows: While attempting to debug this (and not realising that it was a hard-coded variable issue), I also wrote some basic code for automatically finding the first available potion ID if no entry in the config file exists - this is in AMConfig.java. While it should be fully functional, bad luck means that it is far from perfect - in principle, this code should be well behaved and co-operative, but it's also loaded near the beginning (simply because the mod's name starts with A) and other mods may not be so nice with their own hard-coded potion ID values.

While it should theoretically be possible to change the potion allocations later in the startup procedure by making a table of what potions we allocate, and then checking that against what we end up with in post-initialisation (assuming that this is the final step before main menu), I don't know how "final" the potion list is after it's been created - some things might rely on the potion list after the allocation stage, for instance.

This also means that we're now bending over backwards to play nice with misbehaving mods who don't look at what they're stepping on. I have no idea what to do if this happens when we've already got a full config file (for instance - after adding a new mod to a complete installation, you might have buff or debuff effects active in your save which should not be arbitrarily re-assigned).

The automatic potion ID allocation in its current state is therefore functional, but not particularly useful unless you're adding AM2 to a modpack whose other contents start with AA to AL. I don't believe that it causes any harm, hence I've left it in the code for this pull request.