### PR TITLE
Fixed spell projectiles targeting entity parts

### DIFF
--- a/src/main/java/am2/entities/EntitySpellProjectile.java
+++ b/src/main/java/am2/entities/EntitySpellProjectile.java
@@ -288,6 +288,9 @@ public class EntitySpellProjectile extends Entity{
 		}
 
 		if (entity != null){
+			if (entity instanceof EntityDragonPart && ((EntityDragonPart)entity).entityDragonObj != null && ((EntityDragonPart)entity).entityDragonObj instanceof EntityLivingBase) {
+				entity = (EntityLivingBase)((EntityDragonPart)entity).entityDragonObj;
+			}
 			movingobjectposition = new MovingObjectPosition(entity);
 		}
 		if (movingobjectposition != null){


### PR DESCRIPTION
In the process of working with `EntityDragonPart` (should be named `EntityPart`, as it isn't specific to the ender dragon), I inadvertently found the source of the bug where projectile spells would have no effect on the ender dragon.

A projectile spells check if it hits an entity that extends `EntityLivingBase` so that it can do damage and apply status effects. However, entity parts only extend `Entity`, causing the spell to ignore all `EntityDragonPart` entities.

To fix this, I use the exact same method `EntityPlayer.attackTargetEntityWithCurrentItem()` uses to attack an entity part: check if the struck entity is a part, then set the struck entity to the parent of the part.