### PR TITLE
Fixed boss bounding boxes not properly responding to projectiles

### DIFF
--- a/src/main/java/am2/bosses/AM2Boss.java
+++ b/src/main/java/am2/bosses/AM2Boss.java
@@ -36,12 +36,22 @@ public abstract class AM2Boss extends EntityMob implements IArsMagicaBoss, IEnti
 	}
 
 	//Bosses should be able to follow players through doors and hallways, so setSize is overridden to instead add a
-	//damageable bounding box of the specified size, unless a boss already uses parts.
+	//damageable entity based bounding box of the specified size, unless a boss already uses parts.
 	@Override
 	public void setSize(float width, float height){
 		if (parts == null){
-			parts = new EntityDragonPart[]{new EntityDragonPart(this, "defaultBody", width, height)};
-			parts[0].noClip = false;
+			parts = new EntityDragonPart[]{new EntityDragonPart(this, "defaultBody", width, height){
+				@Override
+				public void onUpdate(){
+					super.onUpdate();
+					this.isDead = ((Entity)entityDragonObj).isDead;
+				}
+
+				@Override
+				public boolean shouldRenderInPass(int pass){
+					return false;
+				}
+			}};
 		}else{
 			super.setSize(width, height);
 		}
@@ -181,7 +191,10 @@ public abstract class AM2Boss extends EntityMob implements IArsMagicaBoss, IEnti
 
 		if (parts != null && parts[0] != null && parts[0].field_146032_b == "defaultBody"){
 			parts[0].setPosition(this.posX, this.posY, this.posZ);
-			parts[0].onUpdate();
+			parts[0].setVelocity(this.motionX, this.motionY, this.motionZ);
+			if (!parts[0].addedToChunk){
+				this.worldObj.spawnEntityInWorld(parts[0]);
+			}
 		}
 
 		this.ticksInCurrentAction++;


### PR DESCRIPTION
Whoops, looks like there's a small quirk with the minecraft engine where a projectile can't hit an entity part (`EntityDragonPart`) without first hitting the parent entity, so my extra large body parts of the bosses were not being taken into account by projectiles (melee attacks work just fine, projectiles sometimes appear to work but actually don't).

My alternate method is to give the entity parts a little more form by directly spawning them into the world, not just counting on MC's code to manage them. After a few tweaks and many many tests later, this is what the end result is.

Again, the only bug that might pop up is if a player tries to right-click/interact with a boss, the action may be cancelled (touch spells still work).