### PR TITLE
Fix tile entities double-rendering and sometimes crashing clients when broken

### DIFF
--- a/src/main/java/am2/blocks/renderers/TechneBlockRenderHandler.java
+++ b/src/main/java/am2/blocks/renderers/TechneBlockRenderHandler.java
@@ -62,16 +62,7 @@ public class TechneBlockRenderHandler implements ISimpleBlockRenderingHandler{
 
 	@Override
 	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer){
-
-		if (!(world instanceof World) && !(world instanceof GuiBlockAccess)){
-			return false;
-		}
-
-		TileEntity TE = world.getTileEntity(x, y, z);
-
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(TE, x, y, z, 0.0F);
-
-		return true;
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
After digging through to try and fix #1243, I eventually found that tile entities were being rendered twice, once as the block and once as the tile entity.

This worked just fine until a tile entity called a different renderer (e.g. the calcinator calling the item renderer to display the smelting item) and the block was being broken at the same time. The tile entity render would occur just fine, but the block render would cause the client to crash as the client tried to tessellate both the non-tile renderer and the block renderer at the same time.

This pull request fixes #1243 and similar issues by removing the extra block render.