### PR TITLE
Grow component: Apply bonemeal-like effect to all growables

### DIFF
--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -111,6 +111,21 @@ public class Grow implements ISpellComponent{
 		if (world.rand.nextInt(10) < 8)
 			return true;
 
+		// EoD: Apply vanilla bonemeal effect to growables. See ItemDye.applyBonemeal()
+		if (block instanceof IGrowable){
+			IGrowable igrowable = (IGrowable)block;
+			//FMLLog.getLogger().info("Grow component found IGrowable");
+
+			if (igrowable.func_149851_a(world, blockx, blocky, blockz, world.isRemote)){
+				if (!world.isRemote){
+					if (igrowable.func_149852_a(world, world.rand, blockx, blocky, blockz)){
+						igrowable.func_149853_b(world, world.rand, blockx, blocky, blockz);
+					}
+				}
+				return true;
+			}
+		}
+
 		if (!world.isRemote){
 			blocky++;
 			if (world.getBlock(blockx, blocky, blockz) == Blocks.air){


### PR DESCRIPTION
The Grow Component behaves weird and I tried to clean it up a bit.

This commit applies the vanilla bonemeal effect to *all* IGrowables every now and then (``world.rand.nextInt(10) < 8``) if they are not specifically handled before. Before, nothing happened when applied to grass. I don't know why this doesn't work even though this has been fixed in #594.

This works just fine with projectile but there is still a bug with "Zone+AoE". You need to dig one block below the surface where you want to apply the effect. I think this is a bug in Zone+AoE which does not search the blocks properly.