### PR TITLE
Fix AMUICFG command asking for permission from server

### DIFF
--- a/src/main/java/am2/AMCore.java
+++ b/src/main/java/am2/AMCore.java
@@ -41,6 +41,7 @@ import net.minecraft.command.ServerCommandManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
 import net.minecraftforge.common.BiomeManager;
@@ -210,11 +211,11 @@ public class AMCore{
 		serverCommandManager.registerCommand(new GiveSkillPoints());
 		serverCommandManager.registerCommand(new TakeSkillPoints());
 		serverCommandManager.registerCommand(new ClearKnownSpellParts());
-		serverCommandManager.registerCommand(new ConfigureAMUICommand());
 		serverCommandManager.registerCommand(new Explosions());
 		serverCommandManager.registerCommand(new DumpNBT());
 		serverCommandManager.registerCommand(new Respec());
 		serverCommandManager.registerCommand(new UnlockCompendiumEntry());
+		ClientCommandHandler.instance.registerCommand(new ConfigureAMUICommand());
 	}
 
 	@EventHandler

--- a/src/main/java/am2/commands/ConfigureAMUICommand.java
+++ b/src/main/java/am2/commands/ConfigureAMUICommand.java
@@ -1,9 +1,9 @@
 package am2.commands;
 
-import am2.AMCore;
+import am2.guis.GuiHudCustomization;
+import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayerMP;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +39,11 @@ public class ConfigureAMUICommand extends CommandBase{
 
 	@Override
 	public void processCommand(ICommandSender icommandsender, String[] astring){
-		EntityPlayerMP player = getCommandSenderAsPlayer(icommandsender);
-		AMCore.proxy.guiManager.showUICustomizationScreen(player);
+		new Thread(){
+			public void run(){
+				Minecraft.getMinecraft().displayGuiScreen(new GuiHudCustomization());
+			}
+		}.start();
 	}
 
 }

--- a/src/main/java/am2/commands/ConfigureAMUICommand.java
+++ b/src/main/java/am2/commands/ConfigureAMUICommand.java
@@ -10,6 +10,15 @@ import java.util.List;
 
 public class ConfigureAMUICommand extends CommandBase{
 
+	private static boolean showGUI = false;
+
+	public static void showIfQueued(){
+		if (showGUI){
+			Minecraft.getMinecraft().displayGuiScreen(new GuiHudCustomization());
+			showGUI = false;
+		}
+	}
+
 	@Override
 	public String getCommandName(){
 		return "amuicfg";
@@ -39,11 +48,7 @@ public class ConfigureAMUICommand extends CommandBase{
 
 	@Override
 	public void processCommand(ICommandSender icommandsender, String[] astring){
-		new Thread(){
-			public void run(){
-				Minecraft.getMinecraft().displayGuiScreen(new GuiHudCustomization());
-			}
-		}.start();
+		showGUI = true;
 	}
 
 }

--- a/src/main/java/am2/network/AMPacketIDs.java
+++ b/src/main/java/am2/network/AMPacketIDs.java
@@ -23,7 +23,8 @@ public class AMPacketIDs{
 	public static final byte SYNC_AFFINITY_DATA = 34;
 	public static final byte DECO_BLOCK_UPDATE = 35;
 	public static final byte INSCRIPTION_TABLE_UPDATE = 36;
-	public static final byte SHOW_UI_CUSTOMIZATION = 37;
+	//No longer needed
+	//public static final byte SHOW_UI_CUSTOMIZATION = 37;
 	public static final byte ENTITY_ACTION_UPDATE = 38;
 	public static final byte TK_DISTANCE_SYNC = 39;
 	public static final byte SAVE_KEYSTONE_COMBO = 40;

--- a/src/main/java/am2/network/AMPacketProcessorClient.java
+++ b/src/main/java/am2/network/AMPacketProcessorClient.java
@@ -106,9 +106,6 @@ public class AMPacketProcessorClient extends AMPacketProcessorServer{
 			case AMPacketIDs.SYNC_SPELL_KNOWLEDGE:
 				handleSyncSpellKnowledge(remaining);
 				break;
-			case AMPacketIDs.SHOW_UI_CUSTOMIZATION:
-				openUICustomization();
-				break;
 			case AMPacketIDs.ENTITY_ACTION_UPDATE:
 				handleEntityActionUpdate(remaining, player);
 				break;

--- a/src/main/java/am2/proxy/gui/ServerGuiManager.java
+++ b/src/main/java/am2/proxy/gui/ServerGuiManager.java
@@ -158,9 +158,4 @@ public class ServerGuiManager implements IGuiHandler{
 	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z){
 		return getServerGuiElement(ID, player, world, x, y, z);
 	}
-
-	public void showUICustomizationScreen(EntityPlayerMP player){
-		if (!player.worldObj.isRemote)
-			AMNetHandler.INSTANCE.sendPacketToClientPlayer(player, AMPacketIDs.SHOW_UI_CUSTOMIZATION, new byte[0]);
-	}
 }

--- a/src/main/java/am2/proxy/tick/ClientTickHandler.java
+++ b/src/main/java/am2/proxy/tick/ClientTickHandler.java
@@ -11,6 +11,7 @@ import am2.api.spell.component.interfaces.ISpellComponent;
 import am2.armor.ArmorHelper;
 import am2.armor.infusions.GenericImbuement;
 import am2.bosses.BossSpawnHelper;
+import am2.commands.ConfigureAMUICommand;
 import am2.guis.AMGuiHelper;
 import am2.guis.AMIngameGUI;
 import am2.guis.GuiHudCustomization;
@@ -288,6 +289,7 @@ public class ClientTickHandler{
 
 		if (Minecraft.getMinecraft().thePlayer != null && Minecraft.getMinecraft().theWorld != null && (Minecraft.getMinecraft().inGameHasFocus || guiScreen instanceof GuiHudCustomization)){
 			this.inGameGui.renderGameOverlay();
+			ConfigureAMUICommand.showIfQueued();
 		}
 	}
 


### PR DESCRIPTION
Fixes #1114, where the client would ask the server to open the AMUICFG gui.

I had to stick the method call to open the GUI in an anonymous thread because the newly opened GUI opened so fast that the command to close the chat GUI would also close the UI config.

If there's a better way to get the right GUI to open and stay open, feel free to implement that.

(Also made sure to test the standalone server this time, and it does work)