### PR TITLE
add liquid etherium name for containers and NEI/waila

### DIFF
--- a/src/main/resources/assets/arsmagica2/lang/de_DE.lang
+++ b/src/main/resources/assets/arsmagica2/lang/de_DE.lang
@@ -142,6 +142,9 @@ tile.arsmagica2:witchwoodSingleSlab.name=Hexholzstufe
 tile.arsmagica2:stairsWitchwood.name=Hexholztreppe
 tile.arsmagica2:liquidEssence.name=Flüssige Essenz
 
+#fluids
+fluid.liquidEssence=Flüssige Essenz
+
 #entities
 entity.arsmagica2.EarthElemental.name=Erdelementar
 entity.arsmagica2.MobFireElemental.name=Feuerelementar

--- a/src/main/resources/assets/arsmagica2/lang/de_DE.lang
+++ b/src/main/resources/assets/arsmagica2/lang/de_DE.lang
@@ -140,6 +140,7 @@ tile.arsmagica2:gold_inlay.name=Goldintarsie
 tile.arsmagica2:planksWitchwood.name=Hexholzplanken
 tile.arsmagica2:witchwoodSingleSlab.name=Hexholzstufe
 tile.arsmagica2:stairsWitchwood.name=Hexholztreppe
+tile.arsmagica2:liquidEssence.name=Flüssige Essenz
 
 #entities
 entity.arsmagica2.EarthElemental.name=Erdelementar

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -235,6 +235,7 @@ tile.arsmagica2:keystoneDoor.name=Keystone Door
 tile.arsmagica2:otherworld_aura.name=Otherworld Aura
 tile.arsmagica2:magetorch.name=Mage Light
 tile.arsmagica2:spell_sealed_door.name=Spell-Sealed Door
+tile.arsmagica2:liquidEssence.name=Liquid Etherium
 
 #entities
 entity.arsmagica2.EarthElemental.name=Earth Elemental

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -237,6 +237,9 @@ tile.arsmagica2:magetorch.name=Mage Light
 tile.arsmagica2:spell_sealed_door.name=Spell-Sealed Door
 tile.arsmagica2:liquidEssence.name=Liquid Etherium
 
+#fluids
+fluid.liquidEssence=Liquid Etherium
+
 #entities
 entity.arsmagica2.EarthElemental.name=Earth Elemental
 entity.arsmagica2.MobFireElemental.name=Fire Elemental


### PR DESCRIPTION
This adds the name for the tile "Liquid Etherium" and a name for the fluid "Liquid Etherium".
This way it can be properly shown in Waila, NEI and in liquid storage tanks from mods like Railcraft or Thermal Expansion.