### PR TITLE
Fixed #1221 of an occasional NPE thrown by an updating Obelisk

### DIFF
--- a/src/main/java/am2/blocks/tileentities/TileEntityObelisk.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityObelisk.java
@@ -171,7 +171,9 @@ public class TileEntityObelisk extends TileEntityAMPower implements IMultiblockS
 	}
 
 	private void sendCookUpdateToClients(){
-		AMNetHandler.INSTANCE.sendObeliskUpdate(this, new AMDataWriter().add(PK_BURNTIME_CHANGE).add(this.burnTimeRemaining).generate());
+		if (!worldObj.isRemote){
+			AMNetHandler.INSTANCE.sendObeliskUpdate(this, new AMDataWriter().add(PK_BURNTIME_CHANGE).add(this.burnTimeRemaining).generate());
+		}
 	}
 
 	public void handlePacket(byte[] data){


### PR DESCRIPTION
Pretty straightforward fix: only have the server send the update to clients, not the client.