### PR TITLE
Death message tweaks

### DIFF
--- a/src/main/java/am2/damage/DamageSourceDarkNexus.java
+++ b/src/main/java/am2/damage/DamageSourceDarkNexus.java
@@ -5,7 +5,7 @@ import net.minecraft.util.DamageSource;
 public class DamageSourceDarkNexus extends DamageSource{
 
 	protected DamageSourceDarkNexus(){
-		super("DarkNexus");
+		super("am2.darkNexus");
 	}
 
 }

--- a/src/main/java/am2/damage/DamageSourceFire.java
+++ b/src/main/java/am2/damage/DamageSourceFire.java
@@ -1,29 +1,12 @@
 package am2.damage;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceFire extends EntityDamageSource{
 	public DamageSourceFire(EntityLivingBase source){
-		super("onFire", source);
+		super("am2.fire", source);
 		this.setFireDamage();
 		this.setDamageBypassesArmor();
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.fire"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return false;
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceFrost.java
+++ b/src/main/java/am2/damage/DamageSourceFrost.java
@@ -1,28 +1,11 @@
 package am2.damage;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceFrost extends EntityDamageSource{
 	public DamageSourceFrost(EntityLivingBase source){
-		super("DamageAMFrost", source);
+		super("am2.frost", source);
 		this.setDamageBypassesArmor();
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.frost"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return false;
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceHoly.java
+++ b/src/main/java/am2/damage/DamageSourceHoly.java
@@ -1,27 +1,11 @@
 package am2.damage;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.IChatComponent;
 
 public class DamageSourceHoly extends EntityDamageSource{
 	public DamageSourceHoly(EntityLivingBase source){
-		super("DamageAM2Holy", source);
+		super("am2.holy", source);
 		this.setDamageBypassesArmor();
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format("Seriously?  How did %s manage to die to healing?  This shouldn't ever happen!", ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return false;
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceLightning.java
+++ b/src/main/java/am2/damage/DamageSourceLightning.java
@@ -1,28 +1,11 @@
 package am2.damage;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceLightning extends EntityDamageSource{
 	public DamageSourceLightning(EntityLivingBase source){
-		super("DamageAMLightning", source);
+		super("am2.lightning", source);
 		this.setDamageBypassesArmor();
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.lightning"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return false;
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceUnsummon.java
+++ b/src/main/java/am2/damage/DamageSourceUnsummon.java
@@ -6,5 +6,6 @@ public class DamageSourceUnsummon extends DamageSource{
 
 	public DamageSourceUnsummon(){
 		super("am2.backfire");
+		this.setDamageAllowedInCreativeMode();
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceUnsummon.java
+++ b/src/main/java/am2/damage/DamageSourceUnsummon.java
@@ -1,28 +1,10 @@
 package am2.damage;
 
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceUnsummon extends DamageSource{
 
 	public DamageSourceUnsummon(){
-		super("DamageAMUnsummon");
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.backfire"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return true;
+		super("am2.backfire");
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceWTFBoom.java
+++ b/src/main/java/am2/damage/DamageSourceWTFBoom.java
@@ -1,29 +1,12 @@
 package am2.damage;
 
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceWTFBoom extends DamageSource{
 
-	protected DamageSourceWTFBoom(String par1String){
-		super(par1String);
+	public DamageSourceWTFBoom(){
+		super("am2.wtfboom");
 		this.setDamageAllowedInCreativeMode();
 		this.setDamageBypassesArmor();
-	}
-
-	public DamageSourceWTFBoom(){
-		this("cactus");
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.wtfboom"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceWind.java
+++ b/src/main/java/am2/damage/DamageSourceWind.java
@@ -1,28 +1,11 @@
 package am2.damage;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EntityDamageSource;
-import net.minecraft.util.IChatComponent;
-import net.minecraft.util.StatCollector;
 
 public class DamageSourceWind extends EntityDamageSource{
 	public DamageSourceWind(EntityLivingBase source){
 		super("DamageAMWind", source);
 		this.setDamageBypassesArmor();
-	}
-
-	@Override
-	public IChatComponent func_151519_b(EntityLivingBase par1EntityLivingBase){
-		if (par1EntityLivingBase instanceof EntityPlayer){
-			return new ChatComponentText(String.format(StatCollector.translateToLocal("am2.death.wind"), ((EntityPlayer)par1EntityLivingBase).getCommandSenderName()));
-		}
-		return super.func_151519_b(par1EntityLivingBase);
-	}
-
-	@Override
-	public boolean canHarmInCreative(){
-		return false;
 	}
 }

--- a/src/main/java/am2/damage/DamageSourceWind.java
+++ b/src/main/java/am2/damage/DamageSourceWind.java
@@ -5,7 +5,7 @@ import net.minecraft.util.EntityDamageSource;
 
 public class DamageSourceWind extends EntityDamageSource{
 	public DamageSourceWind(EntityLivingBase source){
-		super("DamageAMWind", source);
+		super("am2.wind", source);
 		this.setDamageBypassesArmor();
 	}
 }

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -626,12 +626,17 @@ am2.gui.flicker_powerperop=Etherium per operation: %s
 am2.gui.flicker_optime=Op time: %s seconds
 
 #death messages
-am2.death.fire=%s went up in flames.
-am2.death.wind=%s was blown away.
-am2.death.frost=%s was frozen solid.
-am2.death.lightning=%s was electrocuted.
-am2.death.backfire=%s's spell backfired.
-am2.death.wtfboom=%s hit the cactus too hard, then blew up swimming in lava.
+death.attack.am2.fire=%1$s went up in flames because of %2$s
+death.attack.am2.wind=%1$s was blown away by %2$s
+death.attack.am2.frost=%1$s was frozen solid by %2$s
+death.attack.am2.lightning=%1$s was electrocuted by %2$s
+death.attack.am2.darkNexus=%s's life force was consumed
+death.attack.am2.darkNexus.player=%1$s's life force was consumed whilst fighting %2$s
+death.attack.am2.backfire=%s's spell backfired
+death.attack.am2.backfire.player=%1$s's spell backfired whilst fighting %2$s
+death.attack.am2.wtfboom=%s hit the cactus too hard, then blew up swimming in lava
+death.attack.am2.wtfboom.player=%1$s hit the cactus too hard, then blew up swimming in lava because of %2$s
+death.attack.am2.holy=%1$s saw the true light of %2$s and disintegrated on the spot
 
 #npc messages
 am2.npc.partyjoin=I have your back!


### PR DESCRIPTION
Modified some of the death messages to better match Minecraft's "death by X because of X" messages.

This also fixes #1194 and similar unlocalized death messages. Some mobs from mods are specially named, so their death is announced. Originally, localization only happened if the dying entity was a player, so I tweaked the death messages to support all entities.

I was a little creative with the holy death message and the dark nexus death message, so feel free to adjust as you feel necessary.