### PR TITLE
Set AM2 EntityDeathEvent to highest priority

### DIFF
--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -25,6 +25,7 @@ import am2.playerextensions.SkillData;
 import am2.utility.*;
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.eventhandler.Event.Result;
+import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.minecraft.block.Block;
@@ -140,7 +141,7 @@ public class AMEventHandler{
 		}
 	}
 
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onEntityDeath(LivingDeathEvent event){
 		String s = EnchantmentSoulbound.class.getName();
 		EntityLivingBase soonToBeDead = event.entityLiving;


### PR DESCRIPTION
Turns out there's a priority modifier for events, so let's have AM2 have a high priority since it has ways of mitigating death and mods that count deaths or trigger something after a death usually are a lower priority.

This should fix #1116, but it is possible the CME could pop up again due to another mod.