### PR TITLE
Fix for non-craftable reflect spell component

### DIFF
--- a/src/main/java/am2/spell/components/Reflect.java
+++ b/src/main/java/am2/spell/components/Reflect.java
@@ -7,6 +7,7 @@ import am2.api.spell.enums.Affinity;
 import am2.api.spell.enums.SpellModifiers;
 import am2.buffs.BuffEffectSpellReflect;
 import am2.buffs.BuffList;
+import am2.blocks.BlocksCommonProxy;
 import am2.items.ItemsCommonProxy;
 import am2.particles.AMParticle;
 import am2.particles.ParticleHoldPosition;
@@ -92,7 +93,7 @@ public class Reflect implements ISpellComponent{
 				new ItemStack(ItemsCommonProxy.rune, 1, ItemsCommonProxy.rune.META_WHITE),
 				Blocks.glass,
 				Blocks.iron_block,
-				"logWood"
+				BlocksCommonProxy.witchwoodLog
 		};
 	}
 


### PR DESCRIPTION
When trying to put Reflect in a spell, one of its required components is "logWood", which is not a valid item (the crafting altar doesn't seem to like ore dictionary lookups). I've changed it to explicitly require a witchwood log, which both fixes the issue and seems more thematically appropriate to the spell than a lump of dead mundane tree.