### PR TITLE
Fixed a log format mistake

### DIFF
--- a/src/main/java/am2/AMChunkLoader.java
+++ b/src/main/java/am2/AMChunkLoader.java
@@ -54,7 +54,7 @@ public class AMChunkLoader implements LoadingCallback{
 	public void requestStaticChunkLoad(Class clazz, int x, int y, int z, World world){
 		Ticket ticket = requestTicket(x, y, z, world);
 		if (ticket == null){
-			AMCore.log.warn("Unable to get a ticket for chunk loading!  The chunk identified by %d, %d is *not* loaded!", x, z);
+			AMCore.log.warn(String.format("Unable to get a ticket for chunk loading!  The chunk identified by %d, %d is *not* loaded!", x, z));
 			return;
 		}
 
@@ -87,7 +87,7 @@ public class AMChunkLoader implements LoadingCallback{
 			try{
 				clazz = Class.forName(clazzName);
 			}catch (ClassNotFoundException e){
-				AMCore.log.info("Cached class not found (%s) when attempting to load a chunk loading ticket.  This ticket will be discarded, and the chunk may not be loaded.  Block Coords: %d, %d", clazzName, coords[0], coords[2]);
+				AMCore.log.info(String.format("Cached class not found (%s) when attempting to load a chunk loading ticket.  This ticket will be discarded, and the chunk may not be loaded.  Block Coords: %d, %d", clazzName, coords[0], coords[2]));
 				ForgeChunkManager.releaseTicket(ticket);
 				continue;
 			}
@@ -96,7 +96,7 @@ public class AMChunkLoader implements LoadingCallback{
 				ChunkCoordIntPair pair = new ChunkCoordIntPair(coords[0] >> 4, coords[2] >> 4);
 				ForgeChunkManager.forceChunk(ticket, pair);
 			}else{
-				AMCore.log.info("Either no tile entity was found or it did not match the cached class.  This chunk loading ticket will be discarded, and the chunk may not be loaded.  Block Coords: %d, %d", coords[0], coords[2]);
+				AMCore.log.info(String.format("Either no tile entity was found or it did not match the cached class.  This chunk loading ticket will be discarded, and the chunk may not be loaded.  Block Coords: %d, %d", coords[0], coords[2]));
 				ForgeChunkManager.releaseTicket(ticket);
 			}
 		}

--- a/src/main/java/am2/api/power/PowerTypes.java
+++ b/src/main/java/am2/api/power/PowerTypes.java
@@ -34,10 +34,10 @@ public final class PowerTypes{
 
 	public static void RegisterPowerType(int id, String name, String chatColor){
 		if (getByID(id) == NONE){
-			AMCore.log.info("Attempted to register power type %s with ID of %d, but that ID is already taken!  The type was NOT registered!", name, id);
+			AMCore.log.info(String.format("Attempted to register power type %s with ID of %d, but that ID is already taken!  The type was NOT registered!", name, id));
 		}else{
 			allPowerTypes.add(new PowerTypes(id, name, chatColor));
-			AMCore.log.info("Registered new power type %s with ID %d", name, id);
+			AMCore.log.info(String.format("Registered new power type %s with ID %d", name, id));
 		}
 	}
 

--- a/src/main/java/am2/armor/infusions/ImbuementRegistry.java
+++ b/src/main/java/am2/armor/infusions/ImbuementRegistry.java
@@ -27,7 +27,7 @@ public class ImbuementRegistry implements IImbuementRegistry{
 	@Override
 	public void registerImbuement(IArmorImbuement imbuementInstance){
 		registeredImbuements.put(imbuementInstance.getID(), imbuementInstance);
-		AMCore.log.info("Registered imbuement: %s", imbuementInstance.getID());
+		AMCore.log.info(String.format("Registered imbuement: %s", imbuementInstance.getID()));
 	}
 
 	@Override

--- a/src/main/java/am2/blocks/tileentities/TileEntityInscriptionTable.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityInscriptionTable.java
@@ -649,7 +649,7 @@ public class TileEntityInscriptionTable extends TileEntity implements IInventory
 				recipeItems = event.recipeItems;
 
 				if (recipeItems == null){
-					AMCore.log.error("Unable to write recipe to book.  Recipe items are null for part %d!", part.getID());
+					AMCore.log.error(String.format("Unable to write recipe to book.  Recipe items are null for part %d!", part.getID()));
 					return bookstack;
 				}
 				for (int i = 0; i < recipeItems.length; ++i){

--- a/src/main/java/am2/blocks/tileentities/flickers/FlickerOperatorRegistry.java
+++ b/src/main/java/am2/blocks/tileentities/flickers/FlickerOperatorRegistry.java
@@ -18,11 +18,11 @@ public class FlickerOperatorRegistry implements IFlickerRegistry{
 	@Override
 	public boolean registerFlickerOperator(IFlickerFunctionality singleton, int mask){
 		if (registeredOperators.containsKey(mask)){
-			AMCore.log.warn("An addon attempted to register a flicker operator (%s) with a mask (%d) that is already in use.  The operator was NOT registered!", singleton.getClass().getName(), mask);
+			AMCore.log.warn(String.format("An addon attempted to register a flicker operator (%s) with a mask (%d) that is already in use.  The operator was NOT registered!", singleton.getClass().getName(), mask));
 			return false;
 		}
 		registeredOperators.put(mask, singleton);
-		AMCore.log.debug("Registered Flicker operator %s to mask %d", singleton.getClass().getName(), mask);
+		AMCore.log.debug(String.format("Registered Flicker operator %s to mask %d", singleton.getClass().getName(), mask));
 		return true;
 	}
 

--- a/src/main/java/am2/buffs/BuffList.java
+++ b/src/main/java/am2/buffs/BuffList.java
@@ -80,10 +80,10 @@ public class BuffList implements IBuffHelper{
 		String configID = name.replace(" ", "").toLowerCase().trim();
 		index = AMCore.config.getConfigurablePotionID(configID, index);
 
-		AMCore.log.info("Potion %s is ID %d", name, index);
+		AMCore.log.info(String.format("Potion %s is ID %d", name, index));
 		
 		if (Potion.potionTypes[index] != null){
-			AMCore.log.error("Warning: Potion index %d is already occupied by potion %s. Check your config files for clashes.", index, Potion.potionTypes[index].getName());
+			AMCore.log.error(String.format("Warning: Potion index %d is already occupied by potion %s. Check your config files for clashes.", index, Potion.potionTypes[index].getName()));
 		}
 
 		ArsMagicaPotion potion = new ArsMagicaPotion(index, isBadEffect, 0x000000);
@@ -100,10 +100,10 @@ public class BuffList implements IBuffHelper{
 		String configID = name.replace(" ", "").toLowerCase().trim();
 		index = AMCore.config.getConfigurablePotionID(configID, index);
 		
-		AMCore.log.info("Potion %s is ID %d", name, index);
+		AMCore.log.info(String.format("Potion %s is ID %d", name, index));
 		
 		if (Potion.potionTypes[index] != null){
-			AMCore.log.error("Warning: Potion index %d is already occupied by potion %s. Check your config files for clashes.", index, Potion.potionTypes[index].getName());
+			AMCore.log.error(String.format("Warning: Potion index %d is already occupied by potion %s. Check your config files for clashes.", index, Potion.potionTypes[index].getName()));
 		}
 		
 		ManaPotion potion = new ManaPotion(index, isBadEffect, colour);
@@ -148,7 +148,7 @@ public class BuffList implements IBuffHelper{
 		// potion clash detection
 		for (Map.Entry<Integer, Potion> entry : ourInitialPotionAllocations.entrySet()){
 			if (Potion.potionTypes[entry.getKey()] != entry.getValue()){
-				AMCore.log.error("My potion, %s, at index %d has been over-written by another potion, %s. You have a conflict in your configuration files.", entry.getValue().getName(), entry.getKey(), Potion.potionTypes[entry.getKey()].getName());
+				AMCore.log.error(String.format("My potion, %s, at index %d has been over-written by another potion, %s. You have a conflict in your configuration files.", entry.getValue().getName(), entry.getKey(), Potion.potionTypes[entry.getKey()].getName()));
 			}
 		}
 	}
@@ -343,9 +343,9 @@ public class BuffList implements IBuffHelper{
 	@Override
 	public void addDispelExclusion(int id){
 		if (dispelBlacklist.contains(id)){
-			AMCore.log.info("Id %d was already on the dispel blacklist; skipping.", id);
+			AMCore.log.info(String.format("Id %d was already on the dispel blacklist; skipping.", id));
 		}else{
-			AMCore.log.info("Added %d to the dispel blacklist.", id);
+			AMCore.log.info(String.format("Added %d to the dispel blacklist.", id));
 			dispelBlacklist.add(id);
 		}
 	}

--- a/src/main/java/am2/configuration/AMConfig.java
+++ b/src/main/java/am2/configuration/AMConfig.java
@@ -337,7 +337,7 @@ public class AMConfig extends Configuration{
 			try{
 				worldgenBlacklist[count] = Integer.parseInt(s.trim());
 			}catch (Throwable t){
-				AMCore.log.info("Malformed item in worldgen blacklist (%s).  Skipping.", s);
+				AMCore.log.info(String.format("Malformed item in worldgen blacklist (%s).  Skipping.", s));
 				t.printStackTrace();
 				worldgenBlacklist[count] = -1;
 			}finally{
@@ -357,7 +357,7 @@ public class AMConfig extends Configuration{
 			try{
 				appropriationMobBlacklist[count] = Class.forName(s);
 			}catch (Throwable t){
-				AMCore.log.info("Malformed item in appropriation entity blacklist (%s).  Skipping.", s);
+				AMCore.log.info(String.format("Malformed item in appropriation entity blacklist (%s).  Skipping.", s));
 				t.printStackTrace();
 				appropriationMobBlacklist[count] = null;
 			}finally{

--- a/src/main/java/am2/enchantments/AMEnchantments.java
+++ b/src/main/java/am2/enchantments/AMEnchantments.java
@@ -37,7 +37,7 @@ public class AMEnchantments{
 			throw new ArrayIndexOutOfBoundsException("All enchantment IDs are in use...can't find a free one to take!");
 		}
 
-		AMCore.log.info("Attempting to set enchantment %s to ID %d (configured currently as %d)", configID, enchID, start_value);
+		AMCore.log.info(String.format("Attempting to set enchantment %s to ID %d (configured currently as %d)", configID, enchID, start_value));
 		AMCore.config.updateConfigurableEnchantmentID(configID, enchID);
 
 		try{
@@ -45,7 +45,7 @@ public class AMEnchantments{
 			AMCore.log.info("Successfully registered enchanment!");
 			return ench;
 		}catch (Throwable t){
-			AMCore.log.error("Failed to register enchantment %s!", configID);
+			AMCore.log.error(String.format("Failed to register enchantment %s!", configID));
 			t.printStackTrace();
 		}
 		return null;

--- a/src/main/java/am2/entities/EntityManager.java
+++ b/src/main/java/am2/entities/EntityManager.java
@@ -205,7 +205,7 @@ public class EntityManager implements IEntityManager{
 
 	private void initSpawnsForBiomeTypes(SpawnListEntry spawnListEntry, EnumCreatureType creatureType, Type[] types, Type[] exclusions){
 		if (spawnListEntry.itemWeight == 0){
-			AMCore.log.info("Skipping spawn list entry for %s (as type %s), as the weight is set to 0.  This can be changed in config.", spawnListEntry.entityClass.getName(), creatureType.toString());
+			AMCore.log.info(String.format("Skipping spawn list entry for %s (as type %s), as the weight is set to 0.  This can be changed in config.", spawnListEntry.entityClass.getName(), creatureType.toString()));
 			return;
 		}
 		for (Type type : types){

--- a/src/main/java/am2/entities/SpawnBlacklists.java
+++ b/src/main/java/am2/entities/SpawnBlacklists.java
@@ -20,9 +20,9 @@ public class SpawnBlacklists{
 		try{
 			clazz = Class.forName(entityClass);
 			blacklistedDimensionSpawns.put(dimensionID, clazz);
-			AMCore.log.info("Blacklisted %s from spawning in dimension %d.", entityClass, dimensionID);
+			AMCore.log.info(String.format("Blacklisted %s from spawning in dimension %d.", entityClass, dimensionID));
 		}catch (ClassNotFoundException e){
-			AMCore.log.info("Unable to parse class name %s from IMC!  This needs to be corrected by the other mod author!", entityClass);
+			AMCore.log.info(String.format("Unable to parse class name %s from IMC!  This needs to be corrected by the other mod author!", entityClass));
 		}
 	}
 
@@ -31,9 +31,9 @@ public class SpawnBlacklists{
 		try{
 			clazz = Class.forName(entityClass);
 			blacklistedBiomeSpawns.put(biomeID, clazz);
-			AMCore.log.info("Blacklisted %s from spawning in biome %d.", entityClass, biomeID);
+			AMCore.log.info(String.format("Blacklisted %s from spawning in biome %d.", entityClass, biomeID));
 		}catch (ClassNotFoundException e){
-			AMCore.log.info("Unable to parse class name %s from IMC!  This needs to be corrected by the other mod author!", entityClass);
+			AMCore.log.info(String.format("Unable to parse class name %s from IMC!  This needs to be corrected by the other mod author!", entityClass));
 		}
 	}
 

--- a/src/main/java/am2/entities/ai/EntityAIApplyPotionOnCollide.java
+++ b/src/main/java/am2/entities/ai/EntityAIApplyPotionOnCollide.java
@@ -104,9 +104,9 @@ public class EntityAIApplyPotionOnCollide extends EntityAIBase{
 				try{
 					ctor = (Constructor<PotionEffect>)_template.getClass().getConstructor(int.class, int.class, int.class);
 				}catch (NoSuchMethodException e1){
-					AMCore.log.trace("Entity AI Potion On Collide Error {0}", e1.getStackTrace().toString());
+					AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e1.getStackTrace().toString()));
 				}catch (SecurityException e1){
-					AMCore.log.trace("Entity AI Potion On Collide Error {0}", e1.getStackTrace().toString());
+					AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e1.getStackTrace().toString()));
 				}
 				if (ctor != null){
 					PotionEffect pe;
@@ -114,13 +114,13 @@ public class EntityAIApplyPotionOnCollide extends EntityAIBase{
 						pe = ctor.newInstance(_template.getPotionID(), _template.getDuration(), _template.getAmplifier());
 						this.entityTarget.addPotionEffect(pe);
 					}catch (InstantiationException e){
-						AMCore.log.trace("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString());
+						AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString()));
 					}catch (IllegalAccessException e){
-						AMCore.log.trace("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString());
+						AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString()));
 					}catch (IllegalArgumentException e){
-						AMCore.log.trace("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString());
+						AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString()));
 					}catch (InvocationTargetException e){
-						AMCore.log.trace("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString());
+						AMCore.log.trace(String.format("Entity AI Potion On Collide Error {0}", e.getStackTrace().toString()));
 					}
 				}
 			}

--- a/src/main/java/am2/items/ItemsCommonProxy.java
+++ b/src/main/java/am2/items/ItemsCommonProxy.java
@@ -1034,7 +1034,7 @@ public class ItemsCommonProxy{
 				if (recipeItems != null){
 					GameRegistry.addRecipe(new ItemStack(flickerFocus, 1, i), recipeItems);
 				}else{
-					AMCore.log.info("Flicker operator %s was registered with no recipe.  It is un-craftable.  This may have been intentional.", func.getClass().getSimpleName());
+					AMCore.log.info(String.format("Flicker operator %s was registered with no recipe.  It is un-craftable.  This may have been intentional.", func.getClass().getSimpleName()));
 				}
 			}
 		}

--- a/src/main/java/am2/lore/ArcaneCompendium.java
+++ b/src/main/java/am2/lore/ArcaneCompendium.java
@@ -249,7 +249,7 @@ public class ArcaneCompendium implements ILoreHelper{
 
 	private void checkForModUpdates(){
 		try{
-			AMCore.log.info("Checking Version.  MC Version: %s", MCVersion);
+			AMCore.log.info(String.format("Checking Version.  MC Version: %s", MCVersion));
 			this.latestModVersion = this.modVersion;
 			String txt = WebRequestUtils.sendPost("http://arcanacraft.qorconcept.com/mc/AM2Versioning.txt", new HashMap<String, String>());
 			String[] lines = txt.replace("\r\n", "\n").split("\n");
@@ -260,13 +260,13 @@ public class ArcaneCompendium implements ILoreHelper{
 				if (!MCVersion.startsWith(sections[0].trim()))
 					continue;
 				if (versionCompare(sections[1], this.latestModVersion) > 0){
-					AMCore.log.info("An update is available.  Version %s is released, detected local version of %s.", this.modVersion, sections[1]);
+					AMCore.log.info(String.format("An update is available.  Version %s is released, detected local version of %s.", this.modVersion, sections[1]));
 					this.latestModVersion = sections[1];
 					this.latestDownloadLink = sections.length >= 3 ? sections[2] : "";
 					this.latestPatchNotesLink = sections.length >= 4 ? sections[3] : "";
 					modUpdateAvailable = true;
 				}else{
-					AMCore.log.info("You are running the latest version of AM2.  Latest Released Version: %s.  Your Version: %s.", this.latestModVersion, this.modVersion);
+					AMCore.log.info(String.format("You are running the latest version of AM2.  Latest Released Version: %s.  Your Version: %s.", this.latestModVersion, this.modVersion));
 				}
 			}
 
@@ -633,19 +633,19 @@ public class ArcaneCompendium implements ILoreHelper{
 	@Override
 	public void AddCompenidumEntry(Object entryItem, String entryKey, String entryName, String entryDesc, String parent, boolean allowReplace, String... relatedKeys){
 		if (entryItem == null){
-			AMCore.log.warn("Null entry item passed.  Cannot add Compendium Entry with key %s.", entryKey);
+			AMCore.log.warn(String.format("Null entry item passed.  Cannot add Compendium Entry with key %s.", entryKey));
 			return;
 		}
 
 		CompendiumEntry existingEntry = getEntry(entryKey);
 		if (existingEntry != null && !allowReplace){
-			AMCore.log.warn("Compendium entry with key %s exists, and allowReplace is false.  The entry was not added.", entryKey);
+			AMCore.log.warn(String.format("Compendium entry with key %s exists, and allowReplace is false.  The entry was not added.", entryKey));
 			return;
 		}
 
 		CompendiumEntry parentEntry = parent == null ? null : getEntry(parent);
 		if (parent != null && parentEntry == null){
-			AMCore.log.warn("The parent ID %s was not found.  Entry %s will be added with no parent.", parent, entryKey);
+			AMCore.log.warn(String.format("The parent ID %s was not found.  Entry %s will be added with no parent.", parent, entryKey));
 		}
 
 		CompendiumEntry newEntry = null;
@@ -679,6 +679,6 @@ public class ArcaneCompendium implements ILoreHelper{
 		}
 
 		this.compendium.put(entryKey, newEntry);
-		AMCore.log.debug("Successfully added compendium entry %s", entryKey);
+		AMCore.log.debug(String.format("Successfully added compendium entry %s", entryKey));
 	}
 }

--- a/src/main/java/am2/lore/CompendiumEntrySpellComponent.java
+++ b/src/main/java/am2/lore/CompendiumEntrySpellComponent.java
@@ -35,7 +35,7 @@ public class CompendiumEntrySpellComponent extends CompendiumEntry{
 						SpellModifiers modifier = Enum.valueOf(SpellModifiers.class, s);
 						list.add(modifier);
 					}catch (Throwable t){
-						AMCore.log.debug("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s);
+						AMCore.log.debug(String.format("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s));
 					}
 				}
 				this.modifiedBy = list.toArray(new SpellModifiers[list.size()]);

--- a/src/main/java/am2/lore/CompendiumEntrySpellModifier.java
+++ b/src/main/java/am2/lore/CompendiumEntrySpellModifier.java
@@ -39,7 +39,7 @@ public class CompendiumEntrySpellModifier extends CompendiumEntry{
 						SpellModifiers modifier = Enum.valueOf(SpellModifiers.class, s);
 						list.add(modifier);
 					}catch (Throwable t){
-						AMCore.log.debug("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s);
+						AMCore.log.debug(String.format("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s));
 					}
 				}
 				this.modifies = list.toArray(new SpellModifiers[list.size()]);

--- a/src/main/java/am2/lore/CompendiumEntrySpellShape.java
+++ b/src/main/java/am2/lore/CompendiumEntrySpellShape.java
@@ -39,7 +39,7 @@ public class CompendiumEntrySpellShape extends CompendiumEntry{
 						SpellModifiers modifier = Enum.valueOf(SpellModifiers.class, s);
 						list.add(modifier);
 					}catch (Throwable t){
-						AMCore.log.debug("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s);
+						AMCore.log.debug(String.format("Compendium Parsing Error - No modifiable constant exists with the name '%s'", s));
 					}
 				}
 				this.modifiedBy = list.toArray(new SpellModifiers[list.size()]);

--- a/src/main/java/am2/network/AMPacketProcessorClient.java
+++ b/src/main/java/am2/network/AMPacketProcessorClient.java
@@ -375,9 +375,9 @@ public class AMPacketProcessorClient extends AMPacketProcessorServer{
 		AMCore.config.setManaCap(manaCap);
 
 		AMCore.log.info("Received player login packet.");
-		AMCore.log.debug("Secondary tree cap: %d", skillTreeLock);
-		AMCore.log.debug("Disabled skills: %d", disabledSkills.length);
-		AMCore.log.debug("Mana cap: %.2f", manaCap);
+		AMCore.log.debug(String.format("Secondary tree cap: %d", skillTreeLock));
+		AMCore.log.debug(String.format("Disabled skills: %d", disabledSkills.length));
+		AMCore.log.debug(String.format("Mana cap: %.2f", manaCap));
 
 		SkillTreeManager.instance.disableAllSkillsIn(disabledSkills);
 	}

--- a/src/main/java/am2/playerextensions/SkillData.java
+++ b/src/main/java/am2/playerextensions/SkillData.java
@@ -585,7 +585,7 @@ public class SkillData implements IExtendedEntityProperties, ISkillData{
 	}
 
 	public void respec(){
-		AMCore.log.info("Respeccing %s", player.getCommandSenderName());
+		AMCore.log.info(String.format("Respeccing %s", player.getCommandSenderName()));
 
 		int[] addPoints = new int[4];
 		addPoints[0] = this.spellPoints[0];

--- a/src/main/java/am2/power/PowerNodeCache.java
+++ b/src/main/java/am2/power/PowerNodeCache.java
@@ -95,7 +95,7 @@ public class PowerNodeCache{
 		if (dataCompound == null){
 			File file = getFileFromChunk(world, chunk, true);
 			if (file == null || (!file.canWrite() && !file.setWritable(true)) || (!file.canRead() && !file.setReadable(true))){
-				AMCore.log.error("Unable to obtain file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read/write access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos);
+				AMCore.log.error(String.format("Unable to obtain file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read/write access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos));
 				return;
 			}
 			try{
@@ -113,7 +113,7 @@ public class PowerNodeCache{
 		if (flushImmediate){
 			File file = getFileFromChunk(world, chunk, true);
 			if (file == null || (!file.canWrite() && !file.setWritable(true)) || (!file.canRead() && !file.setReadable(true))){
-				AMCore.log.error("Unable to obtain file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read/write access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos);
+				AMCore.log.error(String.format("Unable to obtain file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read/write access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos));
 				return;
 			}
 			try{
@@ -137,7 +137,7 @@ public class PowerNodeCache{
 				return null;
 			}
 			if ((!file.canRead() && !file.setReadable(true))){
-				AMCore.log.error("Unable to obtain readable file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos);
+				AMCore.log.error(String.format("Unable to obtain readable file handle!  The power system data for the chunk at %d, %d will NOT be saved!  To fix this, make sure you have read access to the Minecraft instance folder.", chunk.chunkXPos, chunk.chunkZPos));
 				return null;
 			}
 
@@ -211,7 +211,7 @@ public class PowerNodeCache{
 		if (world.isRemote)
 			return;
 
-		AMCore.log.trace("Saving all cached power data for DIM %d to disk", world.provider.dimensionId);
+		AMCore.log.trace(String.format("Saving all cached power data for DIM %d to disk", world.provider.dimensionId));
 
 		//cached data to file
 		Iterator<RegionCoordinates> it = dataCache.keySet().iterator();

--- a/src/main/java/am2/power/PowerNodeEntry.java
+++ b/src/main/java/am2/power/PowerNodeEntry.java
@@ -264,7 +264,7 @@ public class PowerNodeEntry{
 					//register the list of paths and power type
 					nodePaths.put(type, pathsList);
 
-					//	AMCore.log.info("Loaded %d node paths for %s etherium.", pathsList.size(), type.name());
+					//	AMCore.log.info(String.format("Loaded %d node paths for %s etherium.", pathsList.size(), type.name()));
 				}
 			}
 		}

--- a/src/main/java/am2/power/PowerNodeRegistry.java
+++ b/src/main/java/am2/power/PowerNodeRegistry.java
@@ -58,21 +58,21 @@ public class PowerNodeRegistry{
 
 		if (powerNodes.containsKey(chunk)){
 			nodeList = powerNodes.get(chunk);
-			AMCore.log.trace("Located Power Node list for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos);
+			AMCore.log.trace(String.format("Located Power Node list for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos));
 		}else{
 			AMCore.log.trace("Node list not found.  Checking cache/files for prior data");
 			NBTTagCompound compound = PowerNodeCache.instance.getNBTForChunk(world, chunk);
 			nodeList = new HashMap<AMVector3, PowerNodeEntry>();
 			if (compound == null || !compound.hasKey("AM2PowerData")){
 				powerNodes.put(chunk, nodeList);
-				AMCore.log.trace("Prior node list not found.  Created Power Node list for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos);
+				AMCore.log.trace(String.format("Prior node list not found.  Created Power Node list for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos));
 			}else{
 				LoadChunkFromNBT(chunk, compound);
 				nodeList = powerNodes.get(chunk);
 				//sanity check
 				if (nodeList == null)
 					nodeList = new HashMap<AMVector3, PowerNodeEntry>();
-				AMCore.log.trace("Loaded power data for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos);
+				AMCore.log.trace(String.format("Loaded power data for chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos));
 			}
 		}
 
@@ -85,7 +85,7 @@ public class PowerNodeRegistry{
 		PowerNodeEntry pnd = new PowerNodeEntry();
 
 		nodeList.put(nodeLoc, pnd);
-		AMCore.log.trace("Successfully registered power node at {%d, %d, %d}", ((TileEntity)node).xCoord, ((TileEntity)node).yCoord, ((TileEntity)node).zCoord);
+		AMCore.log.trace(String.format("Successfully registered power node at {%d, %d, %d}", ((TileEntity)node).xCoord, ((TileEntity)node).yCoord, ((TileEntity)node).zCoord));
 
 		return pnd;
 	}
@@ -169,13 +169,13 @@ public class PowerNodeRegistry{
 			nodeList = powerNodes.get(chunk);
 			nodeList.remove(location);
 
-			AMCore.log.trace("Successfully removed a node from chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos);
+			AMCore.log.trace(String.format("Successfully removed a node from chunk %d, %d", chunk.chunkXPos, chunk.chunkZPos));
 			if (nodeList.size() == 0){
 				powerNodes.remove(chunk);
 				AMCore.log.trace("No more nodes exist in chunk.  Removing tracking data for chunk.");
 			}
 		}else{
-			AMCore.log.error("Power Node removal requested in a non-tracked chunk (%d, %d)!", chunk.chunkXPos, chunk.chunkZPos);
+			AMCore.log.error(String.format("Power Node removal requested in a non-tracked chunk (%d, %d)!", chunk.chunkXPos, chunk.chunkZPos));
 		}
 	}
 
@@ -339,11 +339,11 @@ public class PowerNodeRegistry{
 		}
 
 		if (deadNodesRemoved > 0)
-			AMCore.log.trace("Removed %d dead power nodes", deadNodesRemoved);
+			AMCore.log.trace(String.format("Removed %d dead power nodes", deadNodesRemoved));
 
 		IPowerNode[] nodeArray = nodes.toArray(new IPowerNode[nodes.size()]);
 
-		AMCore.log.trace("Located %d nearby power providers", nodeArray.length);
+		AMCore.log.trace(String.format("Located %d nearby power providers", nodeArray.length));
 
 		return nodeArray;
 	}
@@ -405,7 +405,7 @@ public class PowerNodeRegistry{
 			powerNodeTagList.appendTag(nodeCompound);
 		}
 
-		AMCore.log.trace("Saved %d power node entries", powerNodeTagList.tagCount());
+		AMCore.log.trace(String.format("Saved %d power node entries", powerNodeTagList.tagCount()));
 
 		compound.setTag("AM2PowerData", powerNodeTagList);
 	}
@@ -424,7 +424,7 @@ public class PowerNodeRegistry{
 			chunkPowerData.put(nodeLocation, pnd);
 		}
 
-		AMCore.log.trace("Loaded %d power node entries", chunkPowerData.size());
+		AMCore.log.trace(String.format("Loaded %d power node entries", chunkPowerData.size()));
 
 		powerNodes.put(chunk, chunkPowerData);
 	}

--- a/src/main/java/am2/preloader/BytecodeTransformers.java
+++ b/src/main/java/am2/preloader/BytecodeTransformers.java
@@ -290,7 +290,7 @@ public class BytecodeTransformers implements IClassTransformer{
 		cr.accept(cn, 0);
 
 		for (MethodNode mn : cn.methods){
-			AMCore.log.debug("%s %s", mn.name, mn.desc);
+			AMCore.log.debug(String.format("%s %s", mn.name, mn.desc));
 			if (mn.name.equals("b_") && mn.desc.equals("(Luf;)V")){ //travelToDimension
 				AbstractInsnNode target = null;
 				AMCore.log.debug("Core: Located target method " + mn.name + mn.desc);
@@ -398,7 +398,7 @@ public class BytecodeTransformers implements IClassTransformer{
 	private void debugPrintInsns(MethodNode mn){
 		Iterator<AbstractInsnNode> it = mn.instructions.iterator();
 
-		AMCore.log.debug("Core: Beginning dump of Insns for %s %s", mn.name, mn.desc);
+		AMCore.log.debug(String.format("Core: Beginning dump of Insns for %s %s", mn.name, mn.desc));
 
 		AMCore.log.debug("================================================================================");
 		AMCore.log.log(Level.INFO, "");

--- a/src/main/java/am2/proxy/tick/ClientTickHandler.java
+++ b/src/main/java/am2/proxy/tick/ClientTickHandler.java
@@ -231,7 +231,7 @@ public class ClientTickHandler{
 				}else if (this.mouseWheelValue < 0 && props.TK_Distance > 0.3){
 					props.TK_Distance -= 0.5f;
 				}
-				AMCore.log.debug("TK Distance: %.2f", props.TK_Distance);
+				AMCore.log.debug(String.format("TK Distance: %.2f", props.TK_Distance));
 				props.syncTKDistance();
 			}else if (stack.getItem() instanceof ItemSpellBook && Minecraft.getMinecraft().thePlayer.isSneaking()){
 				ItemSpellBook isb = (ItemSpellBook)stack.getItem();

--- a/src/main/java/am2/spell/SkillManager.java
+++ b/src/main/java/am2/spell/SkillManager.java
@@ -98,7 +98,7 @@ public class SkillManager implements ISpellPartManager{
 
 		if (registeredParts.containsKey(id)){
 			String existing = reversedPartNames.get(id);
-			AMCore.log.info("Attempted to register duplicate spell part name, %s (which would overwrite %s).  The part was NOT registered.", name, existing);
+			AMCore.log.info(String.format("Attempted to register duplicate spell part name, %s (which would overwrite %s).  The part was NOT registered.", name, existing));
 			return -1;
 		}
 

--- a/src/main/java/am2/spell/SkillTreeManager.java
+++ b/src/main/java/am2/spell/SkillTreeManager.java
@@ -386,7 +386,7 @@ public class SkillTreeManager implements ISkillTreeManager{
 			SkillTreeEntry entry = getSkillTreeEntry(SkillManager.instance.getSkill(i));
 			if (entry != null){
 				entry.enabled = false;
-				AMCore.log.info("Disabling %s as per server configs", SkillManager.instance.getSkillName(entry.registeredItem));
+				AMCore.log.info(String.format("Disabling %s as per server configs", SkillManager.instance.getSkillName(entry.registeredItem)));
 			}else{
 				AMCore.log.warn("Could not disable skill ID %d as per server configs!");
 			}

--- a/src/main/java/am2/spell/SpellRecipeManager.java
+++ b/src/main/java/am2/spell/SpellRecipeManager.java
@@ -35,7 +35,7 @@ public class SpellRecipeManager{
 		recipe = event.recipeItems;
 
 		if (recipe == null){
-			AMCore.log.info("Component %s has been registered with no craftable recipe - is this intentional?  If so, return a 0-length array for recipe.", SkillManager.instance.getDisplayName(part));
+			AMCore.log.info(String.format("Component %s has been registered with no craftable recipe - is this intentional?  If so, return a 0-length array for recipe.", SkillManager.instance.getDisplayName(part)));
 			return;
 		}
 		if (recipe.length == 0){
@@ -89,7 +89,7 @@ public class SpellRecipeManager{
 			try{
 				ids[i] = Integer.parseInt(split[i]);
 			}catch (NumberFormatException nex){
-				AMCore.log.warn("Invalid power type ID while parsing value %s", s);
+				AMCore.log.warn(String.format("Invalid power type ID while parsing value %s", s));
 				ids[i] = 0;
 			}
 		}
@@ -175,7 +175,7 @@ public class SpellRecipeManager{
 
 		if (safeCopy.size() > 0){
 			ISpellPart part = safeCopy.values().iterator().next();
-			AMCore.log.info("Matched Spell Component: %s", part.getClass().toString());
+			AMCore.log.info(String.format("Matched Spell Component: %s", part.getClass().toString()));
 			return part;
 		}
 

--- a/src/main/java/am2/spell/SpellTextureHelper.java
+++ b/src/main/java/am2/spell/SpellTextureHelper.java
@@ -39,7 +39,7 @@ public class SpellTextureHelper{
 			if (resources.size() == 0){
 				AMCore.log.error("No spell IIcons found?!?");
 			}else{
-				AMCore.log.info("Located %d spell IIcons", resources.size());
+				AMCore.log.info(String.format("Located %d spell IIcons", resources.size()));
 			}
 			icons = new IIcon[resources.size()];
 			int count = 0;

--- a/src/main/java/am2/worldgen/RetroactiveWorldgenerator.java
+++ b/src/main/java/am2/worldgen/RetroactiveWorldgenerator.java
@@ -31,7 +31,7 @@ public class RetroactiveWorldgenerator{
 
 			deferredChunkGeneration.put(dimensionID, chunks);
 
-			AMCore.log.info("Retro-genned %d chunks, %d left to generate.", count, chunks.size());
+			AMCore.log.info(String.format("Retro-genned %d chunks, %d left to generate.", count, chunks.size()));
 		}
 	}
 }


### PR DESCRIPTION
Whoops, accidentally removed formatted strings from logs.

This is a little messy, and if wanted we can make a `LogHelper`class similar to `FMLLog` so we don't have to worry about manually running a string through String.format().