### PR TITLE
Tweaked power blocks to update power node registry no mater what method of removal

### DIFF
--- a/src/main/java/am2/blocks/PoweredBlock.java
+++ b/src/main/java/am2/blocks/PoweredBlock.java
@@ -40,7 +40,7 @@ public abstract class PoweredBlock extends AMBlockContainer{
 	@Override
 	public void breakBlock(World par1World, int par2, int par3, int par4, Block par5, int par6){
 		TileEntity myTE = par1World.getTileEntity(par2, par3, par4);
-		if (myTE != null && myTE instanceof TileEntityAMPower){
+		if (myTE != null && myTE instanceof TileEntityAMPower && PowerNodeRegistry.For(par1World).hasDataForChunk(par1World.getChunkFromBlockCoords(myTE.xCoord, myTE.zCoord))){
 			((TileEntityAMPower)myTE).onDeath(par1World);
 		}
 		super.breakBlock(par1World, par2, par3, par4, par5, par6);

--- a/src/main/java/am2/blocks/PoweredBlock.java
+++ b/src/main/java/am2/blocks/PoweredBlock.java
@@ -36,16 +36,6 @@ public abstract class PoweredBlock extends AMBlockContainer{
 		return StatCollector.translateToLocal("am2.gui.powerType" + type.name());
 	}
 
-
-	@Override
-	public void breakBlock(World par1World, int par2, int par3, int par4, Block par5, int par6){
-		TileEntity myTE = par1World.getTileEntity(par2, par3, par4);
-		if (myTE != null && myTE instanceof TileEntityAMPower && PowerNodeRegistry.For(par1World).hasDataForChunk(par1World.getChunkFromBlockCoords(myTE.xCoord, myTE.zCoord))){
-			((TileEntityAMPower)myTE).onDeath(par1World);
-		}
-		super.breakBlock(par1World, par2, par3, par4, par5, par6);
-	}
-
 	@Override
 	public boolean onBlockActivated(World par1World, int par2, int par3, int par4, EntityPlayer par5EntityPlayer, int par6, float par7, float par8, float par9){
 		super.onBlockActivated(par1World, par2, par3, par4, par5EntityPlayer, par6, par7, par8, par9);

--- a/src/main/java/am2/blocks/tileentities/TileEntityAMPower.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityAMPower.java
@@ -34,15 +34,9 @@ public abstract class TileEntityAMPower extends TileEntity implements IPowerNode
 		return false;
 	}
 
-	public void onDeath(World world){
-		PowerNodeRegistry.For(this.worldObj).removePowerNode(this);
-	}
-
 	@Override
 	public void invalidate(){
-		if (worldObj != null && PowerNodeRegistry.For(this.worldObj).hasDataForChunk(this.worldObj.getChunkFromBlockCoords(xCoord, zCoord))){
-			onDeath(this.worldObj);
-		}
+		PowerNodeRegistry.For(this.worldObj).removePowerNode(this);
 		super.invalidate();
 	}
 

--- a/src/main/java/am2/blocks/tileentities/TileEntityAMPower.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityAMPower.java
@@ -39,6 +39,14 @@ public abstract class TileEntityAMPower extends TileEntity implements IPowerNode
 	}
 
 	@Override
+	public void invalidate(){
+		if (worldObj != null && PowerNodeRegistry.For(this.worldObj).hasDataForChunk(this.worldObj.getChunkFromBlockCoords(xCoord, zCoord))){
+			onDeath(this.worldObj);
+		}
+		super.invalidate();
+	}
+
+	@Override
 	public void updateEntity(){
 		if (!worldObj.isRemote && this.canRequestPower() && tickCounter++ >= getRequestInterval()){
 			tickCounter = 0;

--- a/src/main/java/am2/blocks/tileentities/TileEntityKeystoneRecepticle.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityKeystoneRecepticle.java
@@ -124,14 +124,14 @@ public class TileEntityKeystoneRecepticle extends TileEntityAMPower implements I
 	}
 
 	@Override
-	public void onDeath(World world){
+	public void invalidate(){
 		AMCore.instance.proxy.blocks.removeKeystonePortal(xCoord, yCoord, zCoord, worldObj.provider.dimensionId);
 
-		if (!world.isRemote){
+		if (!worldObj.isRemote){
 			AMChunkLoader.INSTANCE.releaseStaticChunkLoad(this.getClass(), this.xCoord, this.yCoord, this.zCoord, this.worldObj);
 		}
 
-		super.onDeath(world);
+		super.invalidate();
 	}
 
 	public void setActive(long key){


### PR DESCRIPTION
From discussion in #1280, this should remove a power node no matter what way a block or tile entity is removed.

Is there a reason onDeath() is separate from invalidate()? It would be a whole lot easier to just have onDeath() called by invalidate().