### PR TITLE
Fixing Rift entity name

### DIFF
--- a/src/main/resources/assets/arsmagica2/lang/de_DE.lang
+++ b/src/main/resources/assets/arsmagica2/lang/de_DE.lang
@@ -255,6 +255,7 @@ entity.arsmagica2.MobMageVillager.name=Magier-Dorfbewohner
 entity.arsmagica2.MobManaCreeper.name=Manacreeper
 entity.arsmagica2.MobManaElemental.name=Manaelementar
 entity.arsmagica2.MobWaterElemental.name=Wasserelementar
+entity.arsmagica2.RiftStorage.name=Spalt
 
 #spells
 am2.spell.validate.compMiss=Mindestens eine Komponente wird benötigt.

--- a/src/main/resources/assets/arsmagica2/lang/en_US.lang
+++ b/src/main/resources/assets/arsmagica2/lang/en_US.lang
@@ -267,6 +267,7 @@ entity.arsmagica2.MobMageVillager.name=Mage Villager
 entity.arsmagica2.MobManaCreeper.name=Mana Creeper
 entity.arsmagica2.MobManaElemental.name=Mana Elemental
 entity.arsmagica2.MobWaterElemental.name=Water Elemental
+entity.arsmagica2.RiftStorage.name=Rift
 
 #spells
 am2.spell.validate.compMiss=At least one component is needed.

--- a/src/main/resources/assets/arsmagica2/lang/es_ES.lang
+++ b/src/main/resources/assets/arsmagica2/lang/es_ES.lang
@@ -254,6 +254,7 @@ entity.arsmagica2.MobMageVillager.name=Mago Aldeano
 entity.arsmagica2.MobManaCreeper.name=Creeper de Maná
 entity.arsmagica2.MobManaElemental.name=Elemental de Maná
 entity.arsmagica2.MobWaterElemental.name=Elemental de Agua
+entity.arsmagica2.RiftStorage.name=Grieta
 
 #spells
 am2.spell.validate.compMiss=Se requiere al menos un componente.

--- a/src/main/resources/assets/arsmagica2/lang/nl_NL.lang
+++ b/src/main/resources/assets/arsmagica2/lang/nl_NL.lang
@@ -198,6 +198,7 @@ entity.arsmagica2.MobMageVillager.name=Tovenaarsdorpeling
 entity.arsmagica2.MobManaCreeper.name=Mana Creeper
 entity.arsmagica2.MobManaElemental.name=Manaelementair
 entity.arsmagica2.MobWaterElemental.name=Waterelementair
+entity.arsmagica2.RiftStorage.name=Rift
 
 #spells
 am2.spell.validate.compMiss=Ten minste een component nodig.

--- a/src/main/resources/assets/arsmagica2/lang/ru_RU.lang
+++ b/src/main/resources/assets/arsmagica2/lang/ru_RU.lang
@@ -250,6 +250,7 @@ entity.arsmagica2.MobMageVillager.name=Маг-житель
 entity.arsmagica2.MobManaCreeper.name=Крипер маны
 entity.arsmagica2.MobManaElemental.name=Элементаль маны
 entity.arsmagica2.MobWaterElemental.name=Элементаль воды
+entity.arsmagica2.RiftStorage.name=Разрыв
 
 #spells
 am2.spell.validate.compMiss=Необходим по крайней мере один компонент.

--- a/src/main/resources/assets/arsmagica2/lang/zh_CN.lang
+++ b/src/main/resources/assets/arsmagica2/lang/zh_CN.lang
@@ -250,6 +250,7 @@ entity.arsmagica2.MobMageVillager.name=巫师村民
 entity.arsmagica2.MobManaCreeper.name=魔力爬行者
 entity.arsmagica2.MobManaElemental.name=魔力元素
 entity.arsmagica2.MobWaterElemental.name=水之元素
+entity.arsmagica2.RiftStorage.name=断裂术
 
 #spells
 am2.spell.validate.compMiss=至少需要一种复合物作为施法材料.


### PR DESCRIPTION
When you spawn a Rift entity (via a Rift spell) it had no name. I just copied the name of the spell to the entity for all languages.