### PR TITLE
Ore Dictionary support for recipes

### DIFF
--- a/src/main/java/am2/blocks/BlocksCommonProxy.java
+++ b/src/main/java/am2/blocks/BlocksCommonProxy.java
@@ -262,20 +262,20 @@ public class BlocksCommonProxy{
 								Character.valueOf('P'), "plankWood",
 								Character.valueOf('O'), Blocks.obsidian,
 								Character.valueOf('A'), "arcaneAsh",
-								Character.valueOf('D'), Items.diamond
+								Character.valueOf('D'), "gemDiamond"
 						}));
 
 		//essence conduit
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(essenceConduit, 1), new Object[]{
 				" C ", " S ", "SSS",
-				Character.valueOf('S'), Blocks.stone,
+				Character.valueOf('S'), "stone",
 				Character.valueOf('C'), "gemChimerite"
 		}));
 
 		//summoner
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(summoner, 1), new Object[]{
 				"GVG", "GOG", "OOO",
-				Character.valueOf('G'), Items.gold_ingot,
+				Character.valueOf('G'), "ingotGold",
 				Character.valueOf('O'), Blocks.obsidian,
 				Character.valueOf('V'), "dustVinteum"
 		}));
@@ -286,8 +286,8 @@ public class BlocksCommonProxy{
 				"SRS",
 				"SVS",
 				Character.valueOf('L'), new ItemStack(Items.dye, 1, 4), //lapis
-				Character.valueOf('S'), Blocks.stone,
-				Character.valueOf('R'), Items.redstone,
+				Character.valueOf('S'), "stone",
+				Character.valueOf('R'), "dustRedstone",
 				Character.valueOf('V'), "dustVinteum"
 		}));
 
@@ -309,12 +309,12 @@ public class BlocksCommonProxy{
 				Character.valueOf('V'), "dustVinteum"
 		}));
 
-		GameRegistry.addRecipe(new ItemStack(seerStone, 1), new Object[]{
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(seerStone, 1), new Object[]{
 				" E ", "SRS",
-				Character.valueOf('S'), Blocks.stone, //stone wall
+				Character.valueOf('S'), "stone", //stone wall
 				Character.valueOf('E'), Items.ender_eye,
-				Character.valueOf('R'), Items.redstone
-		});
+				Character.valueOf('R'), "dustRedstone"
+		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(keystoneChest), new Object[]{
 				"WRW", "WVW", "WRW",
@@ -333,35 +333,35 @@ public class BlocksCommonProxy{
 				"SPS", " S ", "CVC",
 				Character.valueOf('S'), Blocks.stonebrick,
 				Character.valueOf('C'), Items.coal,
-				Character.valueOf('P'), Blocks.glass,
+				Character.valueOf('P'), "blockGlassColorless",
 				Character.valueOf('V'), "gemBlueTopaz"
 		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(blockArcaneReconstructor), new Object[]{
 				"SWS", "VDV", "SOS",
-				Character.valueOf('S'), Blocks.stone,
+				Character.valueOf('S'), "stone",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('D'), Items.diamond,
+				Character.valueOf('D'), "gemDiamond",
 				Character.valueOf('W'), BlocksCommonProxy.magicWall,
 				Character.valueOf('O'), Blocks.obsidian
 		}));
 
-		GameRegistry.addRecipe(new ItemStack(arcaneDeconstructor), new Object[]{
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(arcaneDeconstructor), new Object[]{
 				"IGR",
 				"WDW",
 				"WWW",
 				Character.valueOf('I'), ItemsCommonProxy.itemFocus,
-				Character.valueOf('G'), Blocks.glass,
+				Character.valueOf('G'), "blockGlassColorless",
 				Character.valueOf('R'), new ItemStack(ItemsCommonProxy.essence, 1, ItemsCommonProxy.essence.META_PURE),
 				Character.valueOf('W'), witchwoodPlanks,
 				Character.valueOf('D'), ItemsCommonProxy.deficitCrystal
-		});
+		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(flickerLure), new Object[]{
 				"CIV",
 				"SSS",
 				Character.valueOf('C'), "gemChimerite",
-				Character.valueOf('I'), Items.iron_ingot,
+				Character.valueOf('I'), "ingotIron",
 				Character.valueOf('V'), "dustVinteum",
 				Character.valueOf('S'), Blocks.stonebrick
 		}));
@@ -378,21 +378,21 @@ public class BlocksCommonProxy{
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(magicWall, 16, 0), new Object[]{
 				"VSV",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Blocks.stone
+				Character.valueOf('S'), "stone"
 		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(craftingAltar), new Object[]{
 				"V",
 				"S",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Blocks.stone
+				Character.valueOf('S'), "stone"
 		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(vinteumTorch, 4), new Object[]{
 				"V",
 				"S",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Items.stick
+				Character.valueOf('S'), "stickWood"
 		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(inscriptionTable, new Object[]{
@@ -418,7 +418,7 @@ public class BlocksCommonProxy{
 				"RRR",
 				"RVR",
 				"RRR",
-				Character.valueOf('R'), Items.redstone,
+				Character.valueOf('R'), "dustRedstone",
 				Character.valueOf('V'), "dustVinteum"
 		}));
 
@@ -426,17 +426,17 @@ public class BlocksCommonProxy{
 				"III",
 				"IVI",
 				"III",
-				Character.valueOf('I'), Items.iron_ingot,
+				Character.valueOf('I'), "ingotIron",
 				Character.valueOf('V'), "arcaneAsh"
 		}));
 
-		GameRegistry.addRecipe(new ItemStack(goldInlay, 4, 0), new Object[]{
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(goldInlay, 4, 0), new Object[]{
 				"GGG",
 				"GVG",
 				"GGG",
-				Character.valueOf('G'), Items.gold_ingot,
+				Character.valueOf('G'), "ingotGold",
 				Character.valueOf('V'), new ItemStack(ItemsCommonProxy.itemOre, 1, ItemsCommonProxy.itemOre.META_PURIFIEDVINTEUM)
-		});
+		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(particleEmitter), new Object[]{
 				" C ",
@@ -468,7 +468,7 @@ public class BlocksCommonProxy{
 				"CSC",
 				" B ",
 				Character.valueOf('C'), "gemChimerite",
-				Character.valueOf('S'), Blocks.stone,
+				Character.valueOf('S'), "stone",
 				Character.valueOf('B'), "gemBlueTopaz"
 		}));
 
@@ -476,12 +476,12 @@ public class BlocksCommonProxy{
 				"COC",
 				"SWS",
 				"LHL",
-				Character.valueOf('C'), Blocks.crafting_table,
+				Character.valueOf('C'), "craftingTableWood",
 				Character.valueOf('O'), new ItemStack(Blocks.carpet),
 				Character.valueOf('W'), "logWood",
 				Character.valueOf('S'), "slabWood",
 				Character.valueOf('L'), "plankWood",
-				Character.valueOf('H'), Blocks.chest
+				Character.valueOf('H'), "chestWood"
 		}));
 
 		GameRegistry.addRecipe(new ItemStack(slipstreamGenerator), new Object[]{
@@ -498,7 +498,7 @@ public class BlocksCommonProxy{
 				"IDI",
 				"DBD",
 				"IDI",
-				Character.valueOf('I'), Items.iron_ingot,
+				Character.valueOf('I'), "ingotIron",
 				Character.valueOf('D'), "dustVinteum",
 				Character.valueOf('B'), new ItemStack(AMOres, 1, AMOres.META_CHIMERITE_BLOCK)
 		}));
@@ -605,7 +605,7 @@ public class BlocksCommonProxy{
 				"SCS",
 				"VSV",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Blocks.stone,
+				Character.valueOf('S'), "stone",
 				Character.valueOf('C'), new ItemStack(Blocks.stonebrick, 1, 3)
 		}));
 
@@ -648,6 +648,9 @@ public class BlocksCommonProxy{
 		OreDictionary.registerOre("blockChimerite", new ItemStack(AMOres, 1, AMOres.META_CHIMERITE_BLOCK));
 		OreDictionary.registerOre("blockMoonstone", new ItemStack(AMOres, 1, AMOres.META_MOONSTONE_BLOCK));
 		OreDictionary.registerOre("blockSunstone", new ItemStack(AMOres, 1, AMOres.META_SUNSTONE_BLOCK));
+
+		OreDictionary.registerOre("chestWood", new ItemStack(Blocks.chest));
+		OreDictionary.registerOre("craftingTableWood", new ItemStack(Blocks.crafting_table));
 
 		GameRegistry.addRecipe(new ItemStack(illusionBlock, illusionBlock.GetCraftingQuantity(), 0), illusionBlock.GetRecipeComponents(false));
 		GameRegistry.addRecipe(new ItemStack(illusionBlock, illusionBlock.GetCraftingQuantity(), 1), illusionBlock.GetRecipeComponents(true));

--- a/src/main/java/am2/items/ItemsCommonProxy.java
+++ b/src/main/java/am2/items/ItemsCommonProxy.java
@@ -438,16 +438,16 @@ public class ItemsCommonProxy{
 
 	public void InitRecipes(){
 		//crafting recipes
-		GameRegistry.addRecipe(
+		GameRegistry.addRecipe(new ShapedOreRecipe(
 				new ItemStack(itemOre, 1, itemOre.META_ARCANECOMPOUND),
 				new Object[]
 						{
 								"BRN", "G G", "NRB",
-								Character.valueOf('B'), Blocks.stone,
-								Character.valueOf('R'), Items.redstone,
+								Character.valueOf('B'), "stone",
+								Character.valueOf('R'), "dustRedstone",
 								Character.valueOf('N'), Blocks.netherrack,
-								Character.valueOf('G'), Items.glowstone_dust
-						});
+								Character.valueOf('G'), "dustGlowstone"
+						}));
 
 		//spell crafting
 		GameRegistry.addRecipe(new ShapedOreRecipe(
@@ -478,7 +478,7 @@ public class ItemsCommonProxy{
 						"I I",
 						"AVD",
 						" I ",
-						Character.valueOf('I'), Items.iron_ingot,
+						Character.valueOf('I'), "ingotIron",
 						Character.valueOf('A'), BlocksCommonProxy.cerublossom,
 						Character.valueOf('D'), BlocksCommonProxy.desertNova,
 						Character.valueOf('V'), "dustVinteum",
@@ -523,7 +523,7 @@ public class ItemsCommonProxy{
 				"S",
 				Character.valueOf('P'), "plankWood",
 				Character.valueOf('L'), "slabWood",
-				Character.valueOf('S'), Items.stick
+				Character.valueOf('S'), "stickWood"
 		}));
 
 		GameRegistry.addShapelessRecipe(
@@ -578,12 +578,12 @@ public class ItemsCommonProxy{
 				});
 
 		//blank rune
-		GameRegistry.addRecipe(
+		GameRegistry.addRecipe(new ShapedOreRecipe(
 				new ItemStack(rune, 2, rune.META_BLANK),
 				new Object[]{
 						" S ", "SSS", "SS ",
-						Character.valueOf('S'), Blocks.cobblestone
-				});
+						Character.valueOf('S'), "cobblestone"
+				}));
 		//blue rune
 		GameRegistry.addRecipe(new ShapelessOreRecipe(
 				new ItemStack(rune, 1, rune.META_BLUE),
@@ -709,15 +709,16 @@ public class ItemsCommonProxy{
 				}));
 
 		//empty flicker jar
-		GameRegistry.addRecipe(new ItemStack(flickerJar, 1),
+		GameRegistry.addRecipe(new ShapedOreRecipe(
+				new ItemStack(flickerJar, 1),
 				new Object[]{
 						"NWN",
 						"G G",
 						" G ",
 						Character.valueOf('W'), BlocksCommonProxy.magicWall,
-						Character.valueOf('N'), Items.gold_nugget,
-						Character.valueOf('G'), Blocks.glass_pane
-				});
+						Character.valueOf('N'), "nuggetGold",
+						Character.valueOf('G'), "paneGlassColorless"
+				}));
 
 		//warding candle
 		GameRegistry.addRecipe(new ItemStack(wardingCandle), new Object[]{
@@ -737,7 +738,7 @@ public class ItemsCommonProxy{
 				Character.valueOf('C'), "gemChimerite",
 				Character.valueOf('T'), "gemBlueTopaz",
 				Character.valueOf('L'), Items.leather,
-				Character.valueOf('G'), Items.gold_nugget,
+				Character.valueOf('G'), "nuggetGold",
 		}));
 
 		//magitech staff
@@ -746,7 +747,7 @@ public class ItemsCommonProxy{
 				"G G",
 				"GG ",
 				Character.valueOf('T'), "gemBlueTopaz",
-				Character.valueOf('G'), Items.gold_nugget,
+				Character.valueOf('G'), "nuggetGold",
 		}));
 
 		//armor recipes
@@ -847,18 +848,18 @@ public class ItemsCommonProxy{
 			Character.valueOf('R'), new ItemStack(rune, 1, 6)
 		});*/
 
-		GameRegistry.addRecipe(new ItemStack(essenceBag), new Object[]{
+		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(essenceBag), new Object[]{
 				"LLL", "WNW", "LLL",
 				Character.valueOf('L'), Items.leather,
 				Character.valueOf('W'), new ItemStack(Blocks.wool, 1, AMCore.ANY_META),
-				Character.valueOf('N'), Items.gold_nugget
-		});
+				Character.valueOf('N'), "nuggetGold"
+		}));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(crystalPhylactery), new Object[]{
 				" B ", "GPG", " W ",
 				Character.valueOf('B'), "gemMoonstone",
 				Character.valueOf('W'), BlocksCommonProxy.magicWall,
-				Character.valueOf('G'), Blocks.glass,
+				Character.valueOf('G'), "blockGlassColorless",
 				Character.valueOf('P'), new ItemStack(ItemsCommonProxy.itemOre, 1, ItemsCommonProxy.itemOre.META_PURIFIEDVINTEUM)
 		}));
 
@@ -869,8 +870,8 @@ public class ItemsCommonProxy{
 				"GIG",
 				"IVI",
 				"GIG",
-				Character.valueOf('G'), Items.gold_ingot,
-				Character.valueOf('I'), Items.iron_ingot,
+				Character.valueOf('G'), "ingotGold",
+				Character.valueOf('I'), "ingotIron",
 				Character.valueOf('V'), "dustVinteum"
 		}));
 
@@ -881,12 +882,12 @@ public class ItemsCommonProxy{
 				"arcaneAsh"
 		}));
 
-		GameRegistry.addShapelessRecipe(new ItemStack(manaCake, 3, 0), new Object[]{
+		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(manaCake, 3, 0), new Object[]{
 				new ItemStack(BlocksCommonProxy.cerublossom),
 				new ItemStack(BlocksCommonProxy.desertNova),
 				new ItemStack(Items.sugar),
-				new ItemStack(Items.wheat)
-		});
+				"cropWheat"
+		}));
 
 		GameRegistry.addShapelessRecipe(new ItemStack(lesserManaPotion), new Object[]{
 				new ItemStack(Items.wheat_seeds),
@@ -937,7 +938,7 @@ public class ItemsCommonProxy{
 				"SAS",
 				"SVS",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Items.slime_ball,
+				Character.valueOf('S'), "slimeball",
 				Character.valueOf('A'), Items.golden_axe
 		}));
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(bindingCatalyst, 1, bindingCatalyst.META_PICK), new Object[]{
@@ -945,7 +946,7 @@ public class ItemsCommonProxy{
 				"SAS",
 				"SVS",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Items.slime_ball,
+				Character.valueOf('S'), "slimeball",
 				Character.valueOf('A'), Items.golden_pickaxe
 		}));
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(bindingCatalyst, 1, bindingCatalyst.META_SHOVEL), new Object[]{
@@ -953,7 +954,7 @@ public class ItemsCommonProxy{
 				"SAS",
 				"SVS",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Items.slime_ball,
+				Character.valueOf('S'), "slimeball",
 				Character.valueOf('A'), Items.golden_shovel
 		}));
 		GameRegistry.addRecipe(new ItemStack(bindingCatalyst, 1, bindingCatalyst.META_SWORD), new Object[]{
@@ -961,7 +962,7 @@ public class ItemsCommonProxy{
 				"SAS",
 				"SVS",
 				Character.valueOf('V'), new ItemStack(itemOre, 1, itemOre.META_PURIFIEDVINTEUM),
-				Character.valueOf('S'), Items.slime_ball,
+				Character.valueOf('S'), "slimeball",
 				Character.valueOf('A'), Items.golden_sword
 		});
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(bindingCatalyst, 1, bindingCatalyst.META_HOE), new Object[]{
@@ -969,7 +970,7 @@ public class ItemsCommonProxy{
 				"SAS",
 				"SVS",
 				Character.valueOf('V'), "dustVinteum",
-				Character.valueOf('S'), Items.slime_ball,
+				Character.valueOf('S'), "slimeball",
 				Character.valueOf('A'), Items.golden_hoe
 		}));
 
@@ -992,13 +993,13 @@ public class ItemsCommonProxy{
 				Character.valueOf('K'), new ItemStack(ItemsCommonProxy.itemKeystoneDoor, 1, itemKeystoneDoor.KEYSTONE_DOOR)
 		});
 
-		GameRegistry.addShapelessRecipe(new ItemStack(manaMartini), new Object[]{
+		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(manaMartini), new Object[]{
 				new ItemStack(Blocks.ice),
-				new ItemStack(Items.potato),
+				"cropPotato",
 				new ItemStack(Items.sugar),
-				new ItemStack(Items.stick),
+				"stickWood",
 				new ItemStack(standardManaPotion)
-		});
+		}));
 
 		GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(inscriptionUpgrade, 1, 0),
 				new ItemStack(Items.book),

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -1,5 +1,0 @@
-commands.forge.usage=Use /forge <subcommand>. Subcommands are tps, track
-commands.forge.usage.tracking=Use /forge track <type> <duration>. Valid types are te (Tile Entities). Duration is < 60. 
-commands.forge.tps.summary=%s : Mean tick time: %d ms. Mean TPS: %d
-
-commands.forge.tracking.te.enabled=Tile Entity tracking enabled for %d seconds.

--- a/src/main/resources/assets/forge/lang/es_ES.lang
+++ b/src/main/resources/assets/forge/lang/es_ES.lang
@@ -1,5 +1,0 @@
-commands.forge.usage=Usa /forge <subcomando>. Los subcomandos son tps, track
-commands.forge.usage.tracking=Usa /forge track <tipo> <duración>. Los tipos válidos te (Tile Entities). La duración es < 60. 
-commands.forge.tps.summary=%s : Tiempo de tick medio: %d ms. TPS medio: %d
-
-commands.forge.tracking.te.enabled=Rastreo de Tile Entity activado durante %d segundos.

--- a/src/main/resources/assets/forge/lang/fr_FR.lang
+++ b/src/main/resources/assets/forge/lang/fr_FR.lang
@@ -1,5 +1,0 @@
-﻿commands.forge.usage=Utilisez /forge <sous-commande>. Les sous-commandes sont tps, track
-commands.forge.usage.tracking=Utilisez /forge track <type> <durée>. Les types valides sont te (Tile Entities). La durée doit être inférieur à 60. 
-commands.forge.tps.summary=%s : Duré de tick : %d ms. TPS moyen : %d
-
-commands.forge.tracking.te.enabled=Trackage des Tile Entity activé pour %d secondes.

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 1,
+    "description": "Resources used for Ars Magica 2"
+  }
+}


### PR DESCRIPTION
Changelog:
- Converted all (hopefully) recipes to use Ore Dictionary
- Registered chests and crafting tables in Ore Dictionary to support ganymedes01's [WoodStuff mod](https://github.com/ganymedes01/WoodStuff)
- Removed Forge assets. These are not needed to be in the mod.
- Added pack.mcmeta (Simple file which removes annoying FML log message "missing pack.mcmeta")