### PR TITLE
Rewrite grow spell component

### DIFF
--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -55,24 +55,6 @@ public class Grow implements ISpellComponent{
 			return true;
 		}
 
-		if (world.rand.nextInt(10) < 8)
-			return true;
-
-		// EoD: Apply vanilla bonemeal effect to growables. See ItemDye.applyBonemeal()
-		if (block instanceof IGrowable){
-			IGrowable igrowable = (IGrowable)block;
-			//AMCore.log.getLogger().info("Grow component found IGrowable");
-
-			if (igrowable.func_149851_a(world, blockx, blocky, blockz, world.isRemote)){
-				if (!world.isRemote){
-					if (igrowable.func_149852_a(world, world.rand, blockx, blocky, blockz)){
-						igrowable.func_149853_b(world, world.rand, blockx, blocky, blockz);
-					}
-				}
-				return true;
-			}
-		}
-
 		//If the spell is executed in water, check if we have space for a wakebloom above
 		if (block == Blocks.water){
 			if (world.getBlock(blockx, blocky + 1, blockz) == Blocks.air){
@@ -98,6 +80,25 @@ public class Grow implements ISpellComponent{
 			if (Blocks.tallgrass.canBlockStay(world, blockx, blocky, blockz)){
 				if (!world.isRemote && random.nextInt(10) > 6){
 					world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
+				}
+				return true;
+			}
+		}
+
+		if (world.rand.nextInt(10) < 8)
+			return true;
+
+		// EoD: Apply vanilla bonemeal effect to growables. This is the generic grow section.
+		//      See ItemDye.applyBonemeal().
+		if (block instanceof IGrowable){
+			IGrowable igrowable = (IGrowable)block;
+			//AMCore.log.getLogger().info("Grow component found IGrowable");
+
+			if (igrowable.func_149851_a(world, blockx, blocky, blockz, world.isRemote)){
+				if (!world.isRemote){
+					if (igrowable.func_149852_a(world, world.rand, blockx, blocky, blockz)){
+						igrowable.func_149853_b(world, world.rand, blockx, blocky, blockz);
+					}
 				}
 				return true;
 			}

--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -47,62 +47,9 @@ public class Grow implements ISpellComponent{
 			return true;
 		}
 
-		if (block == Blocks.sapling){
-			if (!world.isRemote){
-				((BlockSapling)Blocks.sapling).func_149878_d(world, blockx, blocky, blockz, world.rand);
-			}
-
-			return true;
-		}
-
 		if (block == Blocks.brown_mushroom || block == Blocks.red_mushroom){
 			if (!world.isRemote){
 				((BlockMushroom)block).func_149884_c(world, blockx, blocky, blockz, world.rand);
-			}
-
-			return true;
-		}
-
-		if (block == Blocks.melon_stem || block == Blocks.pumpkin_stem){
-			if (world.getBlockMetadata(blockx, blocky, blockz) == 7){
-				return false;
-			}
-
-			if (!world.isRemote){
-				((BlockStem)block).func_149874_m(world, blockx, blocky, blockz);
-			}
-
-			return true;
-		}
-
-		if (block instanceof BlockCrops){
-			if (world.getBlockMetadata(blockx, blocky, blockz) == 7){
-				return false;
-			}
-
-			if (!world.isRemote){
-				((BlockCrops)block).func_149863_m(world, blockx, blocky, blockz);
-			}
-
-			return true;
-		}
-
-		if (block == Blocks.cocoa){
-			if (!world.isRemote){
-				int meta = world.getBlockMetadata(blockx, blocky, blockz);
-				int direction = BlockDirectional.getDirection(meta);
-				int something = BlockCocoa.func_149987_c(meta);
-
-				if (something >= 2){
-					return false;
-				}else{
-					if (!world.isRemote){
-						++something;
-						world.setBlockMetadataWithNotify(blockx, blocky, blockz, something << 2 | direction, 2);
-					}
-
-					return true;
-				}
 			}
 
 			return true;

--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -126,20 +126,34 @@ public class Grow implements ISpellComponent{
 			}
 		}
 
-		if (!world.isRemote){
-			blocky++;
-			if (world.getBlock(blockx, blocky, blockz) == Blocks.air){
-				if (world.getBlock(blockx, blocky - 1, blockz) == Blocks.water){
-					world.setBlock(blockx, blocky, blockz, BlocksCommonProxy.wakebloom);
-				}else if ((Blocks.tallgrass.canBlockStay(world, blockx, blocky, blockz) || Blocks.deadbush.canBlockStay(world, blockx, blocky, blockz)) && world.getBlock(blockx, blocky - 1, blockz) != Blocks.dirt && world.getBlock(blockx, blocky - 1, blockz) != Blocks.farmland){
-					if (random.nextInt(10) > 6){
-						if ((Blocks.tallgrass.canBlockStay(world, blockx, blocky, blockz)))
-							world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
-					}
-					return true;
+		//If the spell is executed in water, check if we have space for a wakebloom above
+		if (block == Blocks.water){
+			if (world.getBlock(blockx, blocky + 1, blockz) == Blocks.air){
+				if (!world.isRemote){
+					world.setBlock(blockx, blocky + 1, blockz, BlocksCommonProxy.wakebloom);
 				}
+				return true;
 			}
-			return false;
+		}
+
+		//EoD: If there is already tallgrass present, let's grow it further.
+		if (block == Blocks.tallgrass){
+			if (Blocks.tallgrass.canBlockStay(world, blockx, blocky + 1, blockz)){
+				if (!world.isRemote && random.nextInt(10) > 6){
+					world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
+				}
+				return true;
+			}
+		}
+
+		//EoD: If there is already deadbush present, let's revitalize it. This works only on podzol in vanilla MC.
+		if (block == Blocks.deadbush){
+			if (Blocks.tallgrass.canBlockStay(world, blockx, blocky, blockz)){
+				if (!world.isRemote && random.nextInt(10) > 6){
+					world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
+				}
+				return true;
+			}
 		}
 
 		return true;

--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -47,55 +47,54 @@ public class Grow implements ISpellComponent{
 			return true;
 		}
 
-		if (block == Blocks.brown_mushroom || block == Blocks.red_mushroom){
-			if (!world.isRemote){
+		//Grow huge mushrooms 10% of the time.
+		if (block instanceof BlockMushroom){
+			if (!world.isRemote && random.nextInt(10) < 1){
 				((BlockMushroom)block).func_149884_c(world, blockx, blocky, blockz, world.rand);
 			}
 
 			return true;
 		}
 
-		//If the spell is executed in water, check if we have space for a wakebloom above
+		//If the spell is executed in water, check if we have space for a wakebloom above and create one 10% of the time.
 		if (block == Blocks.water){
 			if (world.getBlock(blockx, blocky + 1, blockz) == Blocks.air){
-				if (!world.isRemote){
+				if (!world.isRemote && random.nextInt(10) < 1){
 					world.setBlock(blockx, blocky + 1, blockz, BlocksCommonProxy.wakebloom);
 				}
 				return true;
 			}
 		}
 
-		//EoD: If there is already tallgrass present, let's grow it further.
+		//EoD: If there is already tallgrass present, let's grow it further 20% of the time.
 		if (block == Blocks.tallgrass){
 			if (Blocks.tallgrass.canBlockStay(world, blockx, blocky + 1, blockz)){
-				if (!world.isRemote && random.nextInt(10) > 6){
+				if (!world.isRemote && random.nextInt(10) < 2){
 					world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
 				}
 				return true;
 			}
 		}
 
-		//EoD: If there is already deadbush present, let's revitalize it. This works only on podzol in vanilla MC.
+		//EoD: If there is already deadbush present, let's revitalize it 20% of the time.
+		//     This works only on podzol in vanilla MC.
 		if (block == Blocks.deadbush){
 			if (Blocks.tallgrass.canBlockStay(world, blockx, blocky, blockz)){
-				if (!world.isRemote && random.nextInt(10) > 6){
+				if (!world.isRemote && random.nextInt(10) < 2){
 					world.setBlock(blockx, blocky, blockz, Blocks.tallgrass, 1, 2);
 				}
 				return true;
 			}
 		}
 
-		if (world.rand.nextInt(10) < 8)
-			return true;
-
-		// EoD: Apply vanilla bonemeal effect to growables. This is the generic grow section.
+		// EoD: Apply vanilla bonemeal effect to growables 30% of the time. This is the generic grow section.
 		//      See ItemDye.applyBonemeal().
 		if (block instanceof IGrowable){
 			IGrowable igrowable = (IGrowable)block;
 			//AMCore.log.getLogger().info("Grow component found IGrowable");
 
 			if (igrowable.func_149851_a(world, blockx, blocky, blockz, world.isRemote)){
-				if (!world.isRemote){
+				if (!world.isRemote && random.nextInt(10) < 3){
 					if (igrowable.func_149852_a(world, world.rand, blockx, blocky, blockz)){
 						igrowable.func_149853_b(world, world.rand, blockx, blocky, blockz);
 					}

--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -41,11 +41,6 @@ public class Grow implements ISpellComponent{
 
 		Block block = world.getBlock(blockx, blocky, blockz);
 
-		if (block == Blocks.farmland){
-			blocky++;
-			block = world.getBlock(blockx, blocky, blockz);
-		}
-
 		BonemealEvent event = new BonemealEvent(DummyEntityPlayer.fromEntityLiving(caster), world, block, blockx, blocky, blockz);
 		if (MinecraftForge.EVENT_BUS.post(event)){
 			return false;


### PR DESCRIPTION
I rewrote the whole Grow component to allow growing of non-vanilla flowers and plants. Additionally I nerfed the spell a lot, such that you need more than one attempt to grow a flower.

I also removed the particle effect on a hit if the target can't grow anything. This way you know if you should hit it more often to grow something or if you should move on.

I will remove the farmland commit once the discussion in #1291 has come to the conclusion.