### PR TITLE
Fixed chrono anchor dimension bug

### DIFF
--- a/src/main/java/am2/AMClientEventHandler.java
+++ b/src/main/java/am2/AMClientEventHandler.java
@@ -26,6 +26,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -329,6 +330,9 @@ public class AMClientEventHandler{
 	public void onEntityJoinWorld(EntityJoinWorldEvent event){
 		if (event.entity instanceof EntityShadowHelper){
 			((EntityShadowHelper)event.entity).onJoinWorld(event.world);
+		}
+		if (event.entity instanceof EntityLivingBase && ((EntityLivingBase)event.entity).isPotionActive(BuffList.temporalAnchor.id)){
+			((EntityLivingBase)event.entity).removePotionEffect(BuffList.temporalAnchor.id);
 		}
 	}
 	

--- a/src/main/java/am2/AMClientEventHandler.java
+++ b/src/main/java/am2/AMClientEventHandler.java
@@ -26,7 +26,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.entity.RenderPlayer;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -330,9 +329,6 @@ public class AMClientEventHandler{
 	public void onEntityJoinWorld(EntityJoinWorldEvent event){
 		if (event.entity instanceof EntityShadowHelper){
 			((EntityShadowHelper)event.entity).onJoinWorld(event.world);
-		}
-		if (event.entity instanceof EntityLivingBase && ((EntityLivingBase)event.entity).isPotionActive(BuffList.temporalAnchor.id)){
-			((EntityLivingBase)event.entity).removePotionEffect(BuffList.temporalAnchor.id);
 		}
 	}
 	

--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -53,6 +53,7 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.event.brewing.PotionBrewedEvent;
 import net.minecraftforge.event.entity.EntityEvent.EntityConstructing;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
@@ -636,6 +637,13 @@ public class AMEventHandler{
 				event.source.getSourceOfDamage() instanceof EntityLivingBase &&
 				((EntityLivingBase)event.source.getSourceOfDamage()).isPotionActive(BuffList.shrink))
 			event.ammount /= 2;
+	}
+
+	@SubscribeEvent
+	public void onEntityJoinWorld(EntityJoinWorldEvent event){
+		if (event.entity instanceof EntityLivingBase && ((EntityLivingBase)event.entity).isPotionActive(BuffList.temporalAnchor.id)){
+			((EntityLivingBase)event.entity).removePotionEffect(BuffList.temporalAnchor.id);
+		}
 	}
 
 	@SubscribeEvent


### PR DESCRIPTION
Fixed #1289 by removing the chrono anchor effect when an entity is spawned into a world (e.g. after it changes dimensions).