### PR TITLE
Fix Tarma Root growth

### DIFF
--- a/src/main/java/am2/blocks/AMFlower.java
+++ b/src/main/java/am2/blocks/AMFlower.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
 import java.util.List;
 
@@ -44,5 +45,7 @@ public class AMFlower extends BlockFlower{
 		list.add(new ItemStack(Item.getItemFromBlock(this), 1, 0));
 	}
 
-
+	public boolean canGrowOn(World worldIn, int x, int y, int z) {
+		return canBlockStay(worldIn, x, y, z);
+	}
 }

--- a/src/main/java/am2/blocks/BlockTarmaRoot.java
+++ b/src/main/java/am2/blocks/BlockTarmaRoot.java
@@ -27,4 +27,10 @@ public class BlockTarmaRoot extends AMFlower{
 	protected boolean canPlaceBlockOn(Block block){
 		return block == Blocks.stone || block == Blocks.cobblestone;
 	}
+
+	//EoD: Tarmas should only grow in dark places
+	@Override
+	public boolean canGrowOn(World worldIn, int x, int y, int z) {
+		return canBlockStay(worldIn, x, y, z) && worldIn.getFullBlockLightValue(x, y, z) < 4;
+	}
 }

--- a/src/main/java/am2/blocks/BlockTarmaRoot.java
+++ b/src/main/java/am2/blocks/BlockTarmaRoot.java
@@ -17,10 +17,10 @@ public class BlockTarmaRoot extends AMFlower{
 		return EnumPlantType.Cave;
 	}
 
+	//EoD: restrict Tarma Roots growth by the blocks in canPlaceBlockOn()
 	@Override
-	public boolean canBlockStay(World par1World, int par2, int par3, int par4){
-		Block block = par1World.getBlock(par2, par3 - 1, par4);
-		return block == Blocks.stone || block == Blocks.cobblestone;
+	public boolean canBlockStay(World worldIn, int x, int y, int z){
+		return canPlaceBlockOn(worldIn.getBlock(x, y - 1, z)) && super.canBlockStay(worldIn, x, y, z);
 	}
 
 	@Override

--- a/src/main/java/am2/spell/components/Grow.java
+++ b/src/main/java/am2/spell/components/Grow.java
@@ -56,7 +56,7 @@ public class Grow implements ISpellComponent{
 			Collections.shuffle(growableAMflowers);
 
 			for (AMFlower flower : growableAMflowers){
-				if (flower.canBlockStay(world, blockx, blocky + 1, blockz)){
+				if (flower.canGrowOn(world, blockx, blocky + 1, blockz)){
 					if (!world.isRemote){
 						world.setBlock(blockx, blocky + 1, blockz, flower, 0, 2);
 					}

--- a/src/main/java/am2/worldgen/AM2FlowerGen.java
+++ b/src/main/java/am2/worldgen/AM2FlowerGen.java
@@ -1,6 +1,6 @@
 package am2.worldgen;
 
-import net.minecraft.block.Block;
+import am2.blocks.AMFlower;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenFlowers;
 
@@ -8,10 +8,10 @@ import java.util.Random;
 
 public class AM2FlowerGen extends WorldGenFlowers{
 
-	private Block plantBlock;
+	private AMFlower plantBlock;
 	private int plantBlockMeta;
 
-	public AM2FlowerGen(Block block, int meta){
+	public AM2FlowerGen(AMFlower block, int meta){
 		super(block);
 		this.plantBlock = block;
 		this.plantBlockMeta = meta;
@@ -19,12 +19,13 @@ public class AM2FlowerGen extends WorldGenFlowers{
 
 	@Override
 	public boolean generate(World par1World, Random par2Random, int par3, int par4, int par5){
+
 		for (int l = 0; l < 8; ++l){
 			int i1 = par3 + par2Random.nextInt(8) - par2Random.nextInt(8);
 			int j1 = par4 + par2Random.nextInt(4) - par2Random.nextInt(4);
 			int k1 = par5 + par2Random.nextInt(8) - par2Random.nextInt(8);
 
-			if (par1World.isAirBlock(i1, j1, k1) && (!par1World.provider.hasNoSky || j1 < 127) && this.plantBlock.canBlockStay(par1World, i1, j1, k1)){
+			if (par1World.isAirBlock(i1, j1, k1) && (!par1World.provider.hasNoSky || j1 < 255) && this.plantBlock.canGrowOn(par1World, i1, j1, k1)){
 				par1World.setBlock(i1, j1, k1, this.plantBlock, this.plantBlockMeta, 2);
 			}
 		}


### PR DESCRIPTION
Currently, Tarma root can grow (naturally and via the growth spell component) on all stone and cobblestone blocks, no matter if it's dark or not.  This change fixes the behaviour and adjusts it such that it only grows in places with ``lightlevel < 4`` and respects the "EnumPlantType.Cave``, similar to the behaviour of mushrooms.