### PR TITLE
Fix crash caused by cycling spell shape with an empty spell book

### DIFF
--- a/src/main/java/am2/AMKeyBindings.java
+++ b/src/main/java/am2/AMKeyBindings.java
@@ -60,6 +60,9 @@ public class AMKeyBindings{
 				shapeGroup = SpellUtils.instance.cycleShapeGroup(curItem);
 			}else{
 				ItemStack spellStack = ((ItemSpellBook)curItem.getItem()).GetActiveItemStack(curItem);
+				if (spellStack == null){
+					return;
+				}
 				shapeGroup = SpellUtils.instance.cycleShapeGroup(spellStack);
 				((ItemSpellBook)curItem.getItem()).replaceAciveItemStack(curItem, spellStack);
 			}


### PR DESCRIPTION
Just a simple NPE fix.