### PR TITLE
Fix for issue #1284 (witchwood forests do not spawn witchwood trees

### DIFF
--- a/src/main/java/am2/worldgen/BiomeWitchwoodForest.java
+++ b/src/main/java/am2/worldgen/BiomeWitchwoodForest.java
@@ -43,13 +43,6 @@ public class BiomeWitchwoodForest extends BiomeGenBase{
 	public int getSkyColorByTemp(float par1){
 		return 0x6699ff;
 	}
-
-	/*
-	@Override
-	public WorldGenerator getRandomWorldGenForGrass(Random rand){
-		return rand.nextDouble() > 0.9f ? hugeTree : smallTree;
-	}
-	*/
 	
 	@Override
 	public WorldGenAbstractTree func_150567_a(Random p_150567_1_)

--- a/src/main/java/am2/worldgen/BiomeWitchwoodForest.java
+++ b/src/main/java/am2/worldgen/BiomeWitchwoodForest.java
@@ -4,6 +4,7 @@ import am2.AMCore;
 import am2.entities.EntityDryad;
 import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.gen.feature.WorldGenAbstractTree;
 import net.minecraft.world.gen.feature.WorldGenerator;
 
 import java.util.Random;
@@ -43,8 +44,16 @@ public class BiomeWitchwoodForest extends BiomeGenBase{
 		return 0x6699ff;
 	}
 
+	/*
 	@Override
 	public WorldGenerator getRandomWorldGenForGrass(Random rand){
 		return rand.nextDouble() > 0.9f ? hugeTree : smallTree;
+	}
+	*/
+	
+	@Override
+	public WorldGenAbstractTree func_150567_a(Random p_150567_1_)
+	{
+	  return (WorldGenAbstractTree)(p_150567_1_.nextInt(10) == 0 ? hugeTree : smallTree);
 	}
 }

--- a/src/main/java/am2/worldgen/WitchwoodTreeHuge.java
+++ b/src/main/java/am2/worldgen/WitchwoodTreeHuge.java
@@ -6,12 +6,12 @@ import net.minecraft.block.BlockSapling;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.WorldGenerator;
+import net.minecraft.world.gen.feature.WorldGenAbstractTree;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Random;
 
-public class WitchwoodTreeHuge extends WorldGenerator{
+public class WitchwoodTreeHuge extends WorldGenAbstractTree{
 	/**
 	 * Contains three sets of two values that provide complimentary indices for a given 'major' index - 1 and 2 for 0, 0
 	 * and 2 for 1, and 0 and 1 for 2.

--- a/src/main/java/am2/worldgen/WitchwoodTreeSmall.java
+++ b/src/main/java/am2/worldgen/WitchwoodTreeSmall.java
@@ -1,42 +1,140 @@
 package am2.worldgen;
 
+import am2.blocks.BlocksCommonProxy;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockSapling;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.WorldGenerator;
+import net.minecraft.world.gen.feature.WorldGenAbstractTree;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.Random;
 
-public class WitchwoodTreeSmall extends WorldGenerator{
-	/**
-	 * The minimum height of a generated tree.
-	 */
-	private final int minTreeHeight;
-
-	/**
-	 * True if this tree should grow Vines.
-	 */
-	private final boolean vinesGrow;
-
-
-	public WitchwoodTreeSmall(boolean par1){
-		this(par1, 4, 0, 0, false);
+public class WitchwoodTreeSmall extends WorldGenAbstractTree{
+  
+  private final int minTreeHeight = 4;
+  
+  private final Block logBlock = BlocksCommonProxy.witchwoodLog;
+  private final int logMeta = 0;
+  private final Block leafBlock = BlocksCommonProxy.witchwoodLeaves;
+  private final int leafMeta = 0;
+  
+  // this function is copied from WorldGenTrees.java
+  // variable names have been changed for readability, and some un-used parts (vine, cocoa generation) have been removed
+  public boolean generate(World world, Random random, int x, int y, int z)
+  {
+    int height = random.nextInt(3) + this.minTreeHeight;
+    boolean isValidPlantingSpot = true;
+    
+    if (y >= 1 && y + height + 1 <= 256)
+    {
+      byte leafMaxRadius;
+      Block block;
+      
+      for (int j = y; j <= y + 1 + height; j++)
+      {
+	leafMaxRadius = 1;
+	
+	if (j == y)
+	{
+	  leafMaxRadius = 0;
 	}
-
-	public WitchwoodTreeSmall(boolean par1, int par2, int par3, int par4, boolean par5){
-		super(par1);
-		this.minTreeHeight = par2;
-		this.vinesGrow = par5;
+	
+	if (j >= y + 1 + height - 2)
+	{
+	  leafMaxRadius = 2;
 	}
-
-	@Override
-	public boolean generate(World par1World, Random par2Random, int par3, int par4, int par5){
-		//TODO:
-		return true;
+	
+	for (int i = x - leafMaxRadius; i <= x + leafMaxRadius && isValidPlantingSpot; i++)
+	{
+	  for (int k = z - leafMaxRadius; k <= z + leafMaxRadius && isValidPlantingSpot; k++)
+	  {
+	    if (j >= 0 && j < 256)
+	    {
+	      block = world.getBlock(i, j, k);
+	      
+	      if (!this.isReplaceable(world, i, j, k))
+	      {
+		isValidPlantingSpot = false;
+	      }
+	    }
+	    else
+	    {
+	      isValidPlantingSpot = false;
+	    }
+	  }
 	}
-
-	/**
-	 * Grows vines downward from the given block for a given length. Args: World, x, starty, z, vine-length
-	 */
-	private void growVines(World par1World, int par2, int par3, int par4, int par5){
-		//TODO:
+      }
+      
+      if (!isValidPlantingSpot)
+      {
+	return false;
+      }
+      else
+      {
+	Block block2 = world.getBlock(x, y - 1, z);
+	
+	boolean isSoil = block2.canSustainPlant(world, x, y - 1, z, ForgeDirection.UP, (BlockSapling)Blocks.sapling);
+	if (isSoil && y < 256 - height - 1)
+	{
+	  block2.onPlantGrow(world, x, y - 1, z, x, y, z);
+	  leafMaxRadius = 3;
+	  byte b1 = 0;
+	  
+	  for (int j = y - leafMaxRadius + height; j <= y + height; j++)
+	  {
+	    int treeHeightLayer = j - (y + height);
+	    int leafGenRadius = b1 + 1 - treeHeightLayer / 2;
+	    
+	    for (int i = x - leafGenRadius; i <= x + leafGenRadius; i++)
+	    {
+	      int leafGenDeltaX = i - x;
+	      
+	      for (int k = z - leafGenRadius; k <= z + leafGenRadius; k++)
+	      {
+		int leafGenDeltaZ = k - z;
+		
+		if (Math.abs(leafGenDeltaX) != leafGenRadius || Math.abs(leafGenDeltaZ) != leafGenRadius || random.nextInt(2) != 0 && treeHeightLayer != 0)
+		{
+		  Block block1 = world.getBlock(i, j, k);
+		  
+		  if (block1.isAir(world, i, j, k) || block1.isLeaves(world, i, j, k))
+		  {
+		    this.setBlockAndNotifyAdequately(world, i, j, k, leafBlock, leafMeta);
+		  }
+		}
+	      }
+	    }
+	  }
+	  
+	  for (int j = 0; j < height; j++)
+	  {
+	    block = world.getBlock(x, y + j, z);
+	    
+	    if (block.isAir(world, x, y + j, z) || block.isLeaves(world, x, y + j, z))
+	    {
+	      this.setBlockAndNotifyAdequately(world, x, y + j, z, logBlock, logMeta);
+	    }
+	  }
+	  
+	  return true;
 	}
+	else
+	{
+	  return false;
+	}
+      }
+    }
+    else
+    {
+      return false;
+    }
+  }
+  
+  
+  public WitchwoodTreeSmall(boolean par1){
+    super(par1);
+  }
+  
 }

--- a/src/main/java/am2/worldgen/WitchwoodTreeSmall.java
+++ b/src/main/java/am2/worldgen/WitchwoodTreeSmall.java
@@ -22,119 +22,97 @@ public class WitchwoodTreeSmall extends WorldGenAbstractTree{
   
   // this function is copied from WorldGenTrees.java
   // variable names have been changed for readability, and some un-used parts (vine, cocoa generation) have been removed
-  public boolean generate(World world, Random random, int x, int y, int z)
-  {
-    int height = random.nextInt(3) + this.minTreeHeight;
-    boolean isValidPlantingSpot = true;
-    
-    if (y >= 1 && y + height + 1 <= 256)
-    {
-      byte leafMaxRadius;
-      Block block;
-      
-      for (int j = y; j <= y + 1 + height; j++)
-      {
-	leafMaxRadius = 1;
-	
-	if (j == y)
-	{
-	  leafMaxRadius = 0;
-	}
-	
-	if (j >= y + 1 + height - 2)
-	{
-	  leafMaxRadius = 2;
-	}
-	
-	for (int i = x - leafMaxRadius; i <= x + leafMaxRadius && isValidPlantingSpot; i++)
-	{
-	  for (int k = z - leafMaxRadius; k <= z + leafMaxRadius && isValidPlantingSpot; k++)
-	  {
-	    if (j >= 0 && j < 256)
-	    {
-	      block = world.getBlock(i, j, k);
-	      
-	      if (!this.isReplaceable(world, i, j, k))
-	      {
-		isValidPlantingSpot = false;
-	      }
-	    }
-	    else
-	    {
-	      isValidPlantingSpot = false;
-	    }
-	  }
-	}
-      }
-      
-      if (!isValidPlantingSpot)
-      {
-	return false;
-      }
-      else
-      {
-	Block block2 = world.getBlock(x, y - 1, z);
-	
-	boolean isSoil = block2.canSustainPlant(world, x, y - 1, z, ForgeDirection.UP, (BlockSapling)Blocks.sapling);
-	if (isSoil && y < 256 - height - 1)
-	{
-	  block2.onPlantGrow(world, x, y - 1, z, x, y, z);
-	  leafMaxRadius = 3;
-	  byte b1 = 0;
+  public boolean generate(World world, Random random, int x, int y, int z){
+	  int height = random.nextInt(3) + this.minTreeHeight;
+	  boolean isValidPlantingSpot = true;
 	  
-	  for (int j = y - leafMaxRadius + height; j <= y + height; j++)
-	  {
-	    int treeHeightLayer = j - (y + height);
-	    int leafGenRadius = b1 + 1 - treeHeightLayer / 2;
-	    
-	    for (int i = x - leafGenRadius; i <= x + leafGenRadius; i++)
-	    {
-	      int leafGenDeltaX = i - x;
-	      
-	      for (int k = z - leafGenRadius; k <= z + leafGenRadius; k++)
-	      {
-		int leafGenDeltaZ = k - z;
-		
-		if (Math.abs(leafGenDeltaX) != leafGenRadius || Math.abs(leafGenDeltaZ) != leafGenRadius || random.nextInt(2) != 0 && treeHeightLayer != 0)
-		{
-		  Block block1 = world.getBlock(i, j, k);
+	  if (y >= 1 && y + height + 1 <= 256){
+		  byte leafMaxRadius;
+		  Block block;
 		  
-		  if (block1.isAir(world, i, j, k) || block1.isLeaves(world, i, j, k))
-		  {
-		    this.setBlockAndNotifyAdequately(world, i, j, k, leafBlock, leafMeta);
+		  for (int j = y; j <= y + 1 + height; j++){
+			  leafMaxRadius = 1;
+			  
+			  if (j == y){
+				  leafMaxRadius = 0;
+			  }
+			  
+			  if (j >= y + 1 + height - 2){
+				  leafMaxRadius = 2;
+			  }
+			  
+			  for (int i = x - leafMaxRadius; i <= x + leafMaxRadius && isValidPlantingSpot; i++){
+				  for (int k = z - leafMaxRadius; k <= z + leafMaxRadius && isValidPlantingSpot; k++){
+					  if (j >= 0 && j < 256){
+						  block = world.getBlock(i, j, k);
+						  
+						  if (!this.isReplaceable(world, i, j, k)){
+							  isValidPlantingSpot = false;
+						  }
+					  }
+					  else{
+						  isValidPlantingSpot = false;
+					  }
+				  }
+			  }
 		  }
-		}
-	      }
-	    }
+		  
+		  if (!isValidPlantingSpot){
+			  return false;
+		  }
+		  else{
+			  Block block2 = world.getBlock(x, y - 1, z);
+			  
+			  boolean isSoil = block2.canSustainPlant(world, x, y - 1, z, ForgeDirection.UP, (BlockSapling)Blocks.sapling);
+			  if (isSoil && y < 256 - height - 1){
+				  block2.onPlantGrow(world, x, y - 1, z, x, y, z);
+				  leafMaxRadius = 3;
+				  byte b1 = 0;
+				  
+				  for (int j = y - leafMaxRadius + height; j <= y + height; j++){
+					  int treeHeightLayer = j - (y + height);
+					  int leafGenRadius = b1 + 1 - treeHeightLayer / 2;
+					  
+					  for (int i = x - leafGenRadius; i <= x + leafGenRadius; i++){
+						  int leafGenDeltaX = i - x;
+						  
+						  for (int k = z - leafGenRadius; k <= z + leafGenRadius; k++){
+							  int leafGenDeltaZ = k - z;
+							  
+							  if (Math.abs(leafGenDeltaX) != leafGenRadius || Math.abs(leafGenDeltaZ) != leafGenRadius || random.nextInt(2) != 0 && treeHeightLayer != 0){
+								  Block block1 = world.getBlock(i, j, k);
+								  
+								  if (block1.isAir(world, i, j, k) || block1.isLeaves(world, i, j, k)){
+									  this.setBlockAndNotifyAdequately(world, i, j, k, leafBlock, leafMeta);
+								  }
+							  }
+						  }
+					  }
+				  }
+				  
+				  for (int j = 0; j < height; j++){
+					  block = world.getBlock(x, y + j, z);
+					  
+					  if (block.isAir(world, x, y + j, z) || block.isLeaves(world, x, y + j, z)){
+						  this.setBlockAndNotifyAdequately(world, x, y + j, z, logBlock, logMeta);
+					  }
+				  }
+				  
+				  return true;
+			  }
+			  else{
+				  return false;
+			  }
+		  }
 	  }
-	  
-	  for (int j = 0; j < height; j++)
-	  {
-	    block = world.getBlock(x, y + j, z);
-	    
-	    if (block.isAir(world, x, y + j, z) || block.isLeaves(world, x, y + j, z))
-	    {
-	      this.setBlockAndNotifyAdequately(world, x, y + j, z, logBlock, logMeta);
-	    }
+	  else{
+		  return false;
 	  }
-	  
-	  return true;
-	}
-	else
-	{
-	  return false;
-	}
-      }
-    }
-    else
-    {
-      return false;
-    }
   }
   
   
   public WitchwoodTreeSmall(boolean par1){
-    super(par1);
+	super(par1);
   }
   
 }


### PR DESCRIPTION
This is a fix for issue #1284, caused by the wrong function being over-ridden in BiomeWitchwoodForest.java. func_150567_a(), which returns a WorldGenAbstractTree, is what gets called by the biome decorator, and wasn't over-ridden. This caused Minecraft to revert to its default tree generation behaviour - oak trees.

I've fixed this, and also copied the generation code from the vanilla class (WorldGenTrees.java) into WitchwoodTreeSmall (which didn't have any tree generation code), removed some un-necessary bits (vine and cocoa pod generation) and given the variables more meaningful names than "byte b0" and "int i1".

Witchwood forests now generate witchwood trees as expected. Almost all of them are "small" trees, the same shape as trees that you'll find in vanilla MC forest biomes.