### PR TITLE
Broom: rename getInventory -> getBroomInventory

### DIFF
--- a/src/main/java/am2/entities/EntityBroom.java
+++ b/src/main/java/am2/entities/EntityBroom.java
@@ -200,7 +200,7 @@ public class EntityBroom extends EntityCreature{
 	}
 
 	private void dropInventoryItems(){
-		EntityBroomInventory inventory = this.getInventory();
+		EntityBroomInventory inventory = this.getBroomInventory();
 		for (int i = 0; i < inventory.getSizeInventory(); ++i){
 			ItemStack stack = inventory.getStackInSlot(i);
 			if (stack == null) continue;
@@ -212,7 +212,7 @@ public class EntityBroom extends EntityCreature{
 		return chestLocation;
 	}
 
-	public EntityBroomInventory getInventory(){
+	public EntityBroomInventory getBroomInventory(){
 		return inventory;
 	}
 

--- a/src/main/java/am2/entities/ai/EntityAIChestDeposit.java
+++ b/src/main/java/am2/entities/ai/EntityAIChestDeposit.java
@@ -27,7 +27,7 @@ public class EntityAIChestDeposit extends EntityAIBase{
 		if (iLoc == null)
 			return false;
 
-		if (InventoryUtilities.isInventoryEmpty(host.getInventory()))
+		if (InventoryUtilities.isInventoryEmpty(host.getBroomInventory()))
 			return false;
 		return !host.isInventoryEmpty() && host.isInventoryFull() || ExtendedProperties.For(host).getInanimateTarget() == null;
 	}
@@ -69,7 +69,7 @@ public class EntityAIChestDeposit extends EntityAIBase{
 			depositCounter++;
 
 			if (depositCounter > 10){
-				ItemStack mergeStack = InventoryUtilities.getFirstStackInInventory(host.getInventory()).copy();
+				ItemStack mergeStack = InventoryUtilities.getFirstStackInInventory(host.getBroomInventory()).copy();
 				int originalSize = mergeStack.stackSize;
 				if (!InventoryUtilities.mergeIntoInventory(inventory, mergeStack, 1)){
 					if (te instanceof TileEntityChest){
@@ -89,11 +89,10 @@ public class EntityAIChestDeposit extends EntityAIBase{
 						}
 					}
 				}
-				InventoryUtilities.deductFromInventory(host.getInventory(), mergeStack, originalSize - mergeStack.stackSize);
+				InventoryUtilities.deductFromInventory(host.getBroomInventory(), mergeStack, originalSize - mergeStack.stackSize);
 			}
 
-
-			if (depositCounter > 10 && (InventoryUtilities.isInventoryEmpty(host.getInventory()) || !InventoryUtilities.canMergeHappen(host.getInventory(), inventory))){
+			if (depositCounter > 10 && (InventoryUtilities.isInventoryEmpty(host.getBroomInventory()) || !InventoryUtilities.canMergeHappen(host.getBroomInventory(), inventory))){
 				inventory.closeInventory();
 				resetTask();
 			}


### PR DESCRIPTION
This is a plain renaming of ``getInventory``. ``getInventory()`` would override an implementation in ``EntityLiving`` with the stable10 or later mappings. 

In order to avoid this in the future and to clearly state that the ``getInventory()`` is only valid for Broom,  this PR renames the method.

This commit is based on 967f9fa43735f745007db39c26bacdfd94040637.