### PR TITLE
Update ItemArcaneCompendium.java

### DIFF
--- a/src/main/java/am2/items/ItemArcaneCompendium.java
+++ b/src/main/java/am2/items/ItemArcaneCompendium.java
@@ -1,6 +1,10 @@
 package am2.items;
 
 import am2.guis.AMGuiHelper;
+import am2.texture.ResourceManager;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;

--- a/src/main/java/am2/items/ItemArcaneCompendium.java
+++ b/src/main/java/am2/items/ItemArcaneCompendium.java
@@ -24,4 +24,9 @@ public class ItemArcaneCompendium extends ArsMagicaItem{
 		return false;
 	}
 
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void registerIcons(IIconRegister par1IconRegister){
+		this.itemIcon = ResourceManager.RegisterTexture("arcanecompendium", par1IconRegister);
+	}
 }


### PR DESCRIPTION
When I compiled the dev build I noticed the texture was missing for the Arcane Compendium. Not sure if this was intended or not.. but the fix was simple. It seems the registerIcons method was left out, and adding that with the appropriate texture name fixed the issue.