### PR TITLE
Modified dimension transfers, should fix #1146

### DIFF
--- a/src/main/java/am2/proxy/tick/ClientTickHandler.java
+++ b/src/main/java/am2/proxy/tick/ClientTickHandler.java
@@ -129,7 +129,6 @@ public class ClientTickHandler{
 
 		if (Minecraft.getMinecraft().isIntegratedServerRunning()){
 			MeteorSpawnHelper.instance.tick();
-			applyDeferredDimensionTransfers();
 			applyDeferredPotionEffects();
 		}
 
@@ -331,6 +330,9 @@ public class ClientTickHandler{
 		if (Minecraft.getMinecraft().isIntegratedServerRunning()){
 			if (AMCore.config.retroactiveWorldgen())
 				RetroactiveWorldgenerator.instance.continueRetrogen(event.world);
+		}
+		if (event.phase == TickEvent.Phase.END){
+			applyDeferredDimensionTransfers();
 		}
 	}
 

--- a/src/main/java/am2/proxy/tick/ServerTickHandler.java
+++ b/src/main/java/am2/proxy/tick/ServerTickHandler.java
@@ -66,7 +66,9 @@ public class ServerTickHandler{
 			RetroactiveWorldgenerator.instance.continueRetrogen(event.world);
 
 		applyDeferredPotionEffects();
-		applyDeferredDimensionTransfers();
+		if (event.phase == TickEvent.Phase.END){
+			applyDeferredDimensionTransfers();
+		}
 	}
 
 	private void applyDeferredPotionEffects(){

--- a/src/main/java/am2/spell/components/EnderIntervention.java
+++ b/src/main/java/am2/spell/components/EnderIntervention.java
@@ -47,7 +47,8 @@ public class EnderIntervention implements ISpellComponent{
 				((EntityPlayer)target).addChatMessage(new ChatComponentText("You are already in the nether."));
 			return false;
 		}else{
-			DimensionUtilities.doDimensionTransfer((EntityLivingBase)target, -1);
+//			DimensionUtilities.doDimensionTransfer((EntityLivingBase)target, -1);
+			AMCore.proxy.addDeferredDimensionTransfer((EntityLivingBase)target, -1);
 		}
 
 		return true;

--- a/src/main/java/am2/utility/DimensionUtilities.java
+++ b/src/main/java/am2/utility/DimensionUtilities.java
@@ -20,6 +20,7 @@ public class DimensionUtilities{
 			EntityPlayerMP player = (EntityPlayerMP)entity;
 			new AMTeleporter(player.mcServer.worldServerForDimension(dimension)).teleport(entity);
 		}else{
+			entity.worldObj.theProfiler.startSection("changeDimension");
 			MinecraftServer minecraftserver = MinecraftServer.getServer();
 			int j = entity.dimension;
 			WorldServer worldserver = minecraftserver.worldServerForDimension(j);
@@ -27,9 +28,9 @@ public class DimensionUtilities{
 			entity.dimension = dimension;
 			entity.worldObj.removeEntity(entity);
 			entity.isDead = false;
-
+			entity.worldObj.theProfiler.startSection("reposition");
 			minecraftserver.getConfigurationManager().transferEntityToWorld(entity, j, worldserver, worldserver1, new AMTeleporter(worldserver1));
-
+			entity.worldObj.theProfiler.endStartSection("reloading");
 			Entity e = EntityList.createEntityByName(EntityList.getEntityString(entity), worldserver1);
 
 			if (e != null){
@@ -38,9 +39,10 @@ public class DimensionUtilities{
 			}
 
 			entity.isDead = true;
-
+			entity.worldObj.theProfiler.endSection();
 			worldserver.resetUpdateEntityTick();
 			worldserver1.resetUpdateEntityTick();
+			entity.worldObj.theProfiler.endSection();
 		}
 	}
 


### PR DESCRIPTION
Hello again!

Sorry for the (considerably long) delay for this fix, life got busy for me.

Anyway, I've done some testing with this fix (repeatedly going "up and down" between the nether and the overworld), and I believe this solves #1146.

I also noticed there seems to be some differences between what events fire on what ticks between client (singleplayer) worlds and server worlds. While that's not in the scope of this pull request, it may be something to consider cleaning or clarifying later on.

Fingers crossed this squashes that bug for good!