### PR TITLE
Fixed some scroll bugs

### DIFF
--- a/src/main/java/am2/AMClientEventHandler.java
+++ b/src/main/java/am2/AMClientEventHandler.java
@@ -198,7 +198,7 @@ public class AMClientEventHandler{
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public void onMouseEvent(MouseEvent event){
-		AMCore.proxy.setMouseDWheel(event.dwheel);
+		event.setCanceled(AMCore.proxy.setMouseDWheel(event.dwheel));
 	}
 
 	@SubscribeEvent

--- a/src/main/java/am2/proxy/ClientProxy.java
+++ b/src/main/java/am2/proxy/ClientProxy.java
@@ -197,11 +197,11 @@ public class ClientProxy extends CommonProxy{
 	}
 
 	@Override
-	public void setMouseDWheel(int dwheel){
-		if (dwheel == 0) return;
+	public boolean setMouseDWheel(int dwheel){
+		if (dwheel == 0) return false;
 
 		ItemStack stack = Minecraft.getMinecraft().thePlayer.getCurrentEquippedItem();
-		if (stack == null) return;
+		if (stack == null) return false;
 
 		boolean store = checkForTKMove(stack);
 		if (!store && stack.getItem() instanceof ItemSpellBook){
@@ -210,9 +210,11 @@ public class ClientProxy extends CommonProxy{
 
 		if (store){
 			clientTickHandler.setDWheel(dwheel / 120, Minecraft.getMinecraft().thePlayer.inventory.currentItem, Minecraft.getMinecraft().thePlayer.isUsingItem());
+			return true;
 		}else{
 			clientTickHandler.setDWheel(0, -1, false);
 		}
+		return false;
 	}
 
 	private boolean checkForTKMove(ItemStack stack){

--- a/src/main/java/am2/proxy/CommonProxy.java
+++ b/src/main/java/am2/proxy/CommonProxy.java
@@ -231,7 +231,8 @@ public class CommonProxy{
 	public void openParticleBlockGUI(World world, EntityPlayer player, TileEntityParticleEmitter te){
 	}
 
-	public void setMouseDWheel(int dwheel){
+	public boolean setMouseDWheel(int dwheel){
+		return false;
 	}
 
 	public void renderGameOverlay(){


### PR DESCRIPTION
I found a bug that would sometimes cause MC to "break" away from the spell book while the player was scrolling in the scroll book. I figured out that outright cancelling the mouse event when it's triggered works very well in fixing this bug, and I modified the scroll handling code to do so.