### PR TITLE
Fixed dummy player name showing up in some death messages

### DIFF
--- a/src/main/java/am2/utility/DummyEntityPlayer.java
+++ b/src/main/java/am2/utility/DummyEntityPlayer.java
@@ -14,13 +14,17 @@ public class DummyEntityPlayer extends EntityPlayer{
 	private EntityLivingBase trackEntity = null;
 
 	public DummyEntityPlayer(World world){
-		super(world, new GameProfile(UUID.randomUUID(), "dummyplayer"));
+		this(world, "dummyplayer");
+	}
+
+	public DummyEntityPlayer(World world, String localizedName) {
+		super(world, new GameProfile(UUID.randomUUID(), localizedName));
 	}
 
 	public static EntityPlayer fromEntityLiving(EntityLivingBase entity){
 		if (entity instanceof EntityPlayer) return (EntityPlayer)entity;
 
-		DummyEntityPlayer dep = new DummyEntityPlayer(entity.worldObj);
+		DummyEntityPlayer dep = new DummyEntityPlayer(entity.worldObj, entity.getCommandSenderName());
 		dep.setPosition(entity.posX, entity.posY, entity.posZ);
 		dep.setRotation(entity.rotationYaw, entity.rotationPitch);
 		dep.trackEntity = entity;


### PR DESCRIPTION
I was testing bosses and noticed that the Fire Guardian's firestorm spell, if it killed a player, caused the message "jjtParadox went up in flames because of dummyplayer".

I found that the firestorm spell created a dummy player that did the damage to entities, and said dummy player had the name "dummyplayer". This changes the dummy player so that if it is created from a parent entity, the dummy player takes on the name of the entity that created it.