### PR TITLE
Fixed harvestlevel for ores and witchwood

### DIFF
--- a/src/main/java/am2/blocks/BlockAMOre.java
+++ b/src/main/java/am2/blocks/BlockAMOre.java
@@ -40,6 +40,7 @@ public class BlockAMOre extends BlockOre{
 
 	public BlockAMOre(){
 		super();
+		this.setHarvestLevel("pickaxe", 2);
 	}
 
 	@Override
@@ -132,15 +133,5 @@ public class BlockAMOre extends BlockOre{
 			return MathHelper.clamp_int(random.nextInt(2) + random.nextInt(fortune + 1), 1, 6);
 		}
 		return 1;
-	}
-
-	@Override
-	public int getHarvestLevel(int metadata){
-		return 2;
-	}
-
-	@Override
-	public String getHarvestTool(int metadata){
-		return "pickaxe";
 	}
 }

--- a/src/main/java/am2/blocks/WitchwoodPlanks.java
+++ b/src/main/java/am2/blocks/WitchwoodPlanks.java
@@ -20,6 +20,7 @@ public class WitchwoodPlanks extends BlockWood{
 		super();
 		this.setHardness(2.0f);
 		this.setResistance(2.0f);
+		this.setHarvestLevel("axe", 2);
 	}
 
 	@Override
@@ -45,15 +46,5 @@ public class WitchwoodPlanks extends BlockWood{
 	@Override
 	public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z){
 		return new ItemStack(this);
-	}
-
-	@Override
-	public int getHarvestLevel(int metadata){
-		return 2;
-	}
-
-	@Override
-	public String getHarvestTool(int metadata){
-		return "axe";
 	}
 }

--- a/src/main/java/am2/blocks/WitchwoodSlabs.java
+++ b/src/main/java/am2/blocks/WitchwoodSlabs.java
@@ -20,6 +20,7 @@ public class WitchwoodSlabs extends BlockWoodSlab{
 		super(par2);
 		this.setHardness(2.0f);
 		this.setResistance(2.0f);
+		this.setHarvestLevel("axe", 2);
 	}
 
 	@Override

--- a/src/main/java/am2/blocks/WitchwoodStairs.java
+++ b/src/main/java/am2/blocks/WitchwoodStairs.java
@@ -16,6 +16,7 @@ public class WitchwoodStairs extends BlockStairs{
 		super(par2Block, par3);
 		this.setHardness(2.0f);
 		this.setResistance(2.0f);
+		this.setHarvestLevel("axe", 2);
 	}
 
 	@Override
@@ -26,15 +27,5 @@ public class WitchwoodStairs extends BlockStairs{
 	@Override
 	public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection face){
 		return 0;
-	}
-
-	@Override
-	public int getHarvestLevel(int metadata){
-		return 2;
-	}
-
-	@Override
-	public String getHarvestTool(int metadata){
-		return "axe";
 	}
 }


### PR DESCRIPTION
There was an old problem with a hardcoded harvestlevel for ores, and I found that witchwood slabs were also not matching the harvestlevel or witchwood planks and stairs, which this fixes.

(I will also try to port this to @williewillus's 1.8 branch)