### PR TITLE
Added null check to frame watcher

### DIFF
--- a/src/main/java/am2/ItemFrameWatcher.java
+++ b/src/main/java/am2/ItemFrameWatcher.java
@@ -114,7 +114,7 @@ public class ItemFrameWatcher{
 		queuedAddFrames.clear();
 
 		for (EntityItemFrameComparator comp : toAdd){
-			if (comp.frame.getDisplayedItem() == null || comp.frame.getDisplayedItem().getItem() != ItemsCommonProxy.arcaneCompendium)
+			if (comp.frame != null && (comp.frame.getDisplayedItem() == null || comp.frame.getDisplayedItem().getItem() != ItemsCommonProxy.arcaneCompendium))
 				watchedFrames.put(comp, 0);
 		}
 


### PR DESCRIPTION
One of the issues reported was somehow caused by a null sneaking in where I thought it shouldn't be able to sneak into. No clue how often that'll happen, but this null check should fix the edge case where it does happen.