### PR TITLE
Fix for void damage damaging AM armor, fixes #1314

### DIFF
--- a/src/main/java/am2/armor/AMArmor.java
+++ b/src/main/java/am2/armor/AMArmor.java
@@ -93,7 +93,7 @@ public class AMArmor extends ItemArmor implements ISpecialArmor{
 	public void damageArmor(EntityLivingBase entity, ItemStack stack, DamageSource source, int damage, int slot){
 		if (source == DamageSource.onFire){
 			stack.damageItem(damage * 7, entity);
-		}else if (source == DamageSource.fall || source == DamageSource.inWall || source == DamageSource.drown || source == DamageSource.starve){
+		}else if (source == DamageSource.fall || source == DamageSource.inWall || source == DamageSource.drown || source == DamageSource.starve || source == DamageSource.outOfWorld){
 			return;
 		}else if (source == DamageSource.magic){
 			stack.damageItem(damage * 7, entity);


### PR DESCRIPTION
Just added void damage to the excluded damage list.

EDIT: I meant "fixes #1314"