### PR TITLE
Fix for stacked items causing rituals to break (Addresses part of #1399)

### DIFF
--- a/src/main/java/am2/RitualShapeHelper.java
+++ b/src/main/java/am2/RitualShapeHelper.java
@@ -35,6 +35,17 @@ public class RitualShapeHelper{
 
 			Collections.sort(items, new EntityItemComparator());
 
+			for (int i = 0; i < items.size(); i++){
+				EntityItem item = items.get(i);
+				if (item.getEntityItem().stackSize > 1){
+					EntityItem oneItem = new EntityItem(item.worldObj);
+					oneItem.setEntityItemStack(item.getEntityItem().copy());
+					oneItem.getEntityItem().stackSize = 1;
+					items.add(i, oneItem);
+					item.getEntityItem().stackSize--;
+				}
+			}
+
 			if (!itemsMustMatch || matchReagents((List<EntityItem>)items.clone(), reagents)){
 				ItemStack[] toReturn = new ItemStack[items.size()];
 				for (int i = 0; i < items.size(); ++i)

--- a/src/main/java/am2/entities/EntityItemRune.java
+++ b/src/main/java/am2/entities/EntityItemRune.java
@@ -1,0 +1,16 @@
+package am2.entities;
+
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class EntityItemRune extends EntityItem{
+	public EntityItemRune(World world, double x, double y, double z, ItemStack item){
+		super(world, x, y, z, item);
+	}
+
+	@Override
+	public boolean combineItems(EntityItem item){
+		return false;
+	}
+}

--- a/src/main/java/am2/items/ItemRune.java
+++ b/src/main/java/am2/items/ItemRune.java
@@ -169,7 +169,7 @@ public class ItemRune extends ArsMagicaItem{
 	@Override
 	public Entity createEntity(World world, Entity location, ItemStack itemstack){
 		EntityItem runeEntity = new EntityItemRune(world, location.posX, location.posY, location.posZ, itemstack);
-		if (runeEntity instanceof EntityItem){
+		if (location instanceof EntityItem){
 			EntityItem item = (EntityItem)location;
 			runeEntity.delayBeforeCanPickup = item.delayBeforeCanPickup;
 			runeEntity.motionX = item.motionX;

--- a/src/main/java/am2/items/ItemRune.java
+++ b/src/main/java/am2/items/ItemRune.java
@@ -15,6 +15,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
@@ -157,6 +159,24 @@ public class ItemRune extends ArsMagicaItem{
 		default:
 			return 0;
 		}
+	}
+
+	@Override
+	public boolean hasCustomEntity(ItemStack stack){
+		return stack.stackSize == 1;
+	}
+
+	@Override
+	public Entity createEntity(World world, Entity location, ItemStack itemstack){
+		EntityItem runeEntity = new EntityItemRune(world, location.posX, location.posY, location.posZ, itemstack);
+		if (runeEntity instanceof EntityItem){
+			EntityItem item = (EntityItem)location;
+			runeEntity.delayBeforeCanPickup = item.delayBeforeCanPickup;
+			runeEntity.motionX = item.motionX;
+			runeEntity.motionY = item.motionY;
+			runeEntity.motionZ = item.motionZ;
+		}
+		return runeEntity;
 	}
 
 

--- a/src/main/java/am2/items/ItemRune.java
+++ b/src/main/java/am2/items/ItemRune.java
@@ -169,12 +169,12 @@ public class ItemRune extends ArsMagicaItem{
 	@Override
 	public Entity createEntity(World world, Entity location, ItemStack itemstack){
 		EntityItem runeEntity = new EntityItemRune(world, location.posX, location.posY, location.posZ, itemstack);
+		runeEntity.motionX = location.motionX;
+		runeEntity.motionY = location.motionY;
+		runeEntity.motionZ = location.motionZ;
 		if (location instanceof EntityItem){
 			EntityItem item = (EntityItem)location;
 			runeEntity.delayBeforeCanPickup = item.delayBeforeCanPickup;
-			runeEntity.motionX = item.motionX;
-			runeEntity.motionY = item.motionY;
-			runeEntity.motionZ = item.motionZ;
 		}
 		return runeEntity;
 	}

--- a/src/main/java/am2/items/ItemRune.java
+++ b/src/main/java/am2/items/ItemRune.java
@@ -163,7 +163,7 @@ public class ItemRune extends ArsMagicaItem{
 
 	@Override
 	public boolean hasCustomEntity(ItemStack stack){
-		return stack.stackSize == 1;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
I slightly modified rituals to handle stacked items as individual items.
I also modified runes so that they do not combine if dropped next to each other. This is because the order runes are dropped matters for the rituals to work correctly, and runes that combine into a larger stack can break the order of the dropped runes.

This is verified to not break spell crafting with runes.