### PR TITLE
Fixed mana batteries not keeping power when broken

### DIFF
--- a/src/main/java/am2/AMClientEventHandler.java
+++ b/src/main/java/am2/AMClientEventHandler.java
@@ -181,14 +181,11 @@ public class AMClientEventHandler{
 		}else if (stack.getItem() instanceof ItemBlock){
 			if (((ItemBlock)stack.getItem()).field_150939_a == BlocksCommonProxy.manaBattery){
 				if (stack.hasTagCompound()){
-					NBTTagList list = stack.stackTagCompound.getTagList("Lore", Constants.NBT.TAG_COMPOUND);
-					if (list != null){
-						for (int i = 0; i < list.tagCount(); ++i){
-							NBTBase tag = list.getCompoundTagAt(i);
-							if (tag instanceof NBTTagString){
-								event.toolTip.add((((NBTTagString)tag).func_150285_a_()));
-							}
-						}
+					float batteryCharge = stack.stackTagCompound.getFloat("mana_battery_charge");
+					PowerTypes powerType = PowerTypes.getByID(stack.stackTagCompound.getInteger("mana_battery_powertype"));
+					if (batteryCharge != 0) {
+						// TODO localize this tooltip
+						event.toolTip.add(String.format("\u00A7r\u00A79Contains \u00A75%.2f %s%s \u00A79etherium", batteryCharge, powerType.chatColor(), powerType.name()));
 					}
 				}
 			}

--- a/src/main/java/am2/blocks/renderers/SimpleBlockRenderHandler.java
+++ b/src/main/java/am2/blocks/renderers/SimpleBlockRenderHandler.java
@@ -347,7 +347,7 @@ public class SimpleBlockRenderHandler implements ISimpleBlockRenderingHandler{
 			IBlockAccess old = renderer.blockAccess;
 			renderer.blockAccess = this.blockAccess;
 			this.blockAccess.setControllingTileEntity(te);
-			this.blockAccess.setFakeBlockAndMeta(BlocksCommonProxy.manaBattery, 0);
+			this.blockAccess.setFakeBlockAndMeta(BlocksCommonProxy.manaBattery, te.getPowerType().ID());
 			this.blockAccess.setOuterBlockAccess(world);
 			this.blockAccess.setOverrideCoords(x, y, z);
 			renderer.renderStandardBlock(BlocksCommonProxy.manaBattery, x, y, z);

--- a/src/main/java/am2/blocks/tileentities/TileEntityManaBattery.java
+++ b/src/main/java/am2/blocks/tileentities/TileEntityManaBattery.java
@@ -48,11 +48,16 @@ public class TileEntityManaBattery extends TileEntityAMPower{
 			this.setNoPowerRequests();
 		}
 
-		if (this.outputPowerType == PowerTypes.NONE && !this.worldObj.isRemote){
+		if (!this.worldObj.isRemote){
 			PowerTypes highest = PowerNodeRegistry.For(worldObj).getHighestPowerType(this);
 			float amt = PowerNodeRegistry.For(worldObj).getPower(this, highest);
 			if (amt > 0){
 				this.outputPowerType = highest;
+				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, highest.ID(), 2);
+				worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+			}else{
+				this.outputPowerType = PowerTypes.NONE;
+				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, 0, 2);
 				worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 			}
 		}

--- a/src/main/java/am2/power/PowerNodeRegistry.java
+++ b/src/main/java/am2/power/PowerNodeRegistry.java
@@ -17,7 +17,8 @@ import java.util.*;
 
 public class PowerNodeRegistry{
 
-	private static final HashMap<Integer, PowerNodeRegistry> dimensionPowerManagers = new HashMap<Integer, PowerNodeRegistry>();
+	private static final HashMap<Integer, PowerNodeRegistry> serverDimensionPowerManagers = new HashMap<Integer, PowerNodeRegistry>();
+	private static final HashMap<Integer, PowerNodeRegistry> clientDimensionPowerManagers = new HashMap<Integer, PowerNodeRegistry>();
 	private static final PowerNodeRegistry dummyRegistry = new PowerNodeRegistry();
 
 	static final int POWER_SEARCH_RADIUS = 10; //The literal power search radius
@@ -27,6 +28,8 @@ public class PowerNodeRegistry{
 	public static final PowerNodeRegistry For(World world){
 		if (world == null)
 			return dummyRegistry;
+
+		HashMap<Integer, PowerNodeRegistry> dimensionPowerManagers = world.isRemote ? clientDimensionPowerManagers : serverDimensionPowerManagers;
 
 		if (dimensionPowerManagers.containsKey(world.provider.dimensionId)){
 			return dimensionPowerManagers.get(world.provider.dimensionId);


### PR DESCRIPTION
I looked into some issues that @TheIcyOne was having when he was working on his mana battery changes, and I found a few things.

First, there's a handy method that'll be called before the battery is broken in any way (which I've implemented in this PR).
Second, there was an issue with the power node registry that would mix the server world accessors and the client world accessors together. If the local client asks for a node to be removed, the server looses access to the node, even though the server should have final say in what happens. I resolved this by separating the client and server registries, and so far this has fixed an issue I was having with breaking mana batteries and has not caused any other issues.

I also modified mana batteries to use metadata along with tile entity data, as the 4 kinds of batteries (empty, light, normal, dark) are currently indistinguisable in inventory without viewing the tooltip. Using metadata for the block and item allows for the different kinds of batteries to be rendered differently in inventory (which has not been implemented yet).
Mana battery tooltips work now, too, and can be easily localized (localization not implemented yet).
