### PR TITLE
Applied same specific oredictionaries to 1.8.9

### DIFF
--- a/src/main/java/am2/blocks/BlocksCommonProxy.java
+++ b/src/main/java/am2/blocks/BlocksCommonProxy.java
@@ -771,6 +771,10 @@ public class BlocksCommonProxy{
 		OreDictionary.registerOre("stairWood", witchwoodStairs);
 		OreDictionary.registerOre("plankWood", witchwoodPlanks);
 		OreDictionary.registerOre("slabWood", witchwoodSingleSlab);
+		OreDictionary.registerOre("plankWitchwood", witchwoodPlanks);
+		OreDictionary.registerOre("witchwoodLog", witchwoodLog);
+		OreDictionary.registerOre("stairWitchwood", witchwoodStairs);
+		OreDictionary.registerOre("slabWitchwood", witchwoodSingleSlab);
 	}
 
 	private <T extends ItemBlock> void registerMultiTextureBlock(Block block, String unlocalizedName, T item){

--- a/src/main/java/am2/blocks/BlocksCommonProxy.java
+++ b/src/main/java/am2/blocks/BlocksCommonProxy.java
@@ -775,6 +775,7 @@ public class BlocksCommonProxy{
 		OreDictionary.registerOre("witchwoodLog", witchwoodLog);
 		OreDictionary.registerOre("stairWitchwood", witchwoodStairs);
 		OreDictionary.registerOre("slabWitchwood", witchwoodSingleSlab);
+		OreDictionary.registerOre("treeLeaves", witchwoodLeaves);
 	}
 
 	private <T extends ItemBlock> void registerMultiTextureBlock(Block block, String unlocalizedName, T item){


### PR DESCRIPTION
Applied same specific witchwood oredictionaries for mods to lock onto those if needed as opposed to detecting it via planks

Also, added definitions for leaves.
