### PR TITLE
Fixed preloader not finding mods in mods/1.7.10 folder

### DIFF
--- a/src/main/java/am2/preloader/AM2PreloaderContainer.java
+++ b/src/main/java/am2/preloader/AM2PreloaderContainer.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -83,6 +84,11 @@ public class AM2PreloaderContainer extends DummyModContainer implements IFMLLoad
 
 	@Override
 	public void injectData(Map<String, Object> data){
+		if (((String)data.get("coremodList")).contains("DragonAPIASMHandler")){
+			LogHelper.info("Core: Located DragonAPI in list of coremods");
+			foundDragonAPI = true;
+		}
+
 		// This is very crude check for mods presence using filename.
 		// Some mods may refer to others in their name, so we'll to confirm those assumption with class presence check.
 		File loc = (File)data.get("mcLocation");
@@ -91,7 +97,14 @@ public class AM2PreloaderContainer extends DummyModContainer implements IFMLLoad
 		isDevEnvironment = !(Boolean)data.get("runtimeDeobfuscationEnabled");
 
 		File mcFolder = new File(loc.getAbsolutePath() + File.separatorChar + "mods");
-		File[] subfiles = mcFolder.listFiles();
+		File mcVersionFolder = new File(mcFolder.getAbsolutePath() + File.separatorChar + "1.7.10");
+		ArrayList<File> subfiles = new ArrayList<>();
+		if (mcFolder.listFiles() != null){
+			subfiles = new ArrayList<>(Arrays.asList(mcFolder.listFiles()));
+			if (mcVersionFolder.listFiles() != null){
+				subfiles.addAll(Arrays.asList(mcVersionFolder.listFiles()));
+			}
+		}
 		for (File file : subfiles){
 			String name = file.getName();
 			if (name != null) {


### PR DESCRIPTION
This fixes any crashes caused from having DragonAPI in the wrong folder (fixes #1557, fixes #1555, fixes #1543, and fixes #1534)
