### PR TITLE
Fixed Leap levels shifted by one

### DIFF
--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -463,7 +463,7 @@ public class AMEventHandler{
 
 		//leap buff
 		if (event.entityLiving.isPotionActive(BuffList.leap)){
-			int amplifier = event.entityLiving.getActivePotionEffect(BuffList.leap).getAmplifier() + 1;
+			int amplifier = event.entityLiving.getActivePotionEffect(BuffList.leap).getAmplifier();
 
 			switch (amplifier){
 			case BuffPowerLevel.Low:

--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -227,7 +227,7 @@ public class AMEventHandler{
 			double zVelocity = 0;
 
 			Vec3 vec = event.entityLiving.getLookVec().normalize();
-			switch (event.entityLiving.getActivePotionEffect(BuffList.leap).getAmplifier() + 1){
+			switch (event.entityLiving.getActivePotionEffect(BuffList.leap).getAmplifier()){
 			case BuffPowerLevel.Low:
 				yVelocity = 0.4;
 				xVelocity = velocityTarget.motionX * 1.08 * Math.abs(vec.xCoord);


### PR DESCRIPTION
This fixes the leap level being one off.  
Without this Leap I has the effect of Leap II, Leap II the effect of Leap III and Leap III does nothing at all. (See #1174, #1397, #1612)