### PR TITLE
Fixed Swift Swim not doing anything

### DIFF
--- a/src/main/java/am2/AMEventHandler.java
+++ b/src/main/java/am2/AMEventHandler.java
@@ -489,11 +489,25 @@ public class AMEventHandler{
 
 		//slowfall/shrink buff
 		// (isSneaking calls DataWatcher which are slow, so we test it late)
-		if ( event.entityLiving.isPotionActive(BuffList.slowfall)
-		  || event.entityLiving.isPotionActive(BuffList.shrink)
-		  || (ent instanceof EntityPlayer && AffinityData.For(ent).getAffinityDepth(Affinity.NATURE) == 1.0f && !ent.isSneaking())){
+		if (event.entityLiving.isPotionActive(BuffList.slowfall)
+				|| event.entityLiving.isPotionActive(BuffList.shrink)
+				|| (ent instanceof EntityPlayer && AffinityData.For(ent).getAffinityDepth(Affinity.NATURE) == 1.0f && !ent.isSneaking())){
 			if (!event.entityLiving.onGround && event.entityLiving.motionY < 0.0D){
 				event.entityLiving.motionY *= 0.79999999999999998D;
+			}
+		}
+
+		//swift swim
+		if (event.entityLiving.isPotionActive(BuffList.swiftSwim)){
+			if (event.entityLiving.isInWater()){
+				if (!(event.entityLiving instanceof EntityPlayer) || !((EntityPlayer)event.entityLiving).capabilities.isFlying){
+					event.entityLiving.motionX *= (1.133f + 0.03 * event.entityLiving.getActivePotionEffect(BuffList.swiftSwim).getAmplifier());
+					event.entityLiving.motionZ *= (1.133f + 0.03 * event.entityLiving.getActivePotionEffect(BuffList.swiftSwim).getAmplifier());
+
+					if (event.entityLiving.motionY > 0){
+						event.entityLiving.motionY *= 1.134;
+					}
+				}
 			}
 		}
 
@@ -615,10 +629,10 @@ public class AMEventHandler{
 		}
 
 		Entity entitySource = event.source.getSourceOfDamage();
-		if ( entitySource instanceof EntityPlayer
-		  && ((EntityPlayer)entitySource).inventory.armorInventory[2] != null
-		  && ((EntityPlayer)entitySource).inventory.armorInventory[2].getItem() == ItemsCommonProxy.earthGuardianArmor
-		  && ((EntityPlayer)entitySource).getCurrentEquippedItem() == null ){
+		if (entitySource instanceof EntityPlayer
+				&& ((EntityPlayer)entitySource).inventory.armorInventory[2] != null
+				&& ((EntityPlayer)entitySource).inventory.armorInventory[2].getItem() == ItemsCommonProxy.earthGuardianArmor
+				&& ((EntityPlayer)entitySource).getCurrentEquippedItem() == null){
 			event.ammount += 4;
 
 			double deltaZ = event.entityLiving.posZ - entitySource.posZ;
@@ -649,8 +663,8 @@ public class AMEventHandler{
 		if (ent.isPotionActive(BuffList.fury.id))
 			event.ammount /= 2;
 
-		if ( entitySource instanceof EntityLivingBase
-		  && ((EntityLivingBase)entitySource).isPotionActive(BuffList.shrink))
+		if (entitySource instanceof EntityLivingBase
+				&& ((EntityLivingBase)entitySource).isPotionActive(BuffList.shrink))
 			event.ammount /= 2;
 	}
 

--- a/src/main/java/am2/buffs/BuffEffectSwiftSwim.java
+++ b/src/main/java/am2/buffs/BuffEffectSwiftSwim.java
@@ -1,7 +1,6 @@
 package am2.buffs;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 
 public class BuffEffectSwiftSwim extends BuffEffect{
 
@@ -15,20 +14,6 @@ public class BuffEffectSwiftSwim extends BuffEffect{
 
 	@Override
 	public void stopEffect(EntityLivingBase entityliving){
-	}
-
-	@Override
-	public void performEffect(EntityLivingBase entityliving){
-		if (entityliving.isInWater()){
-			if (!(entityliving instanceof EntityPlayer) || !((EntityPlayer)entityliving).capabilities.isFlying){
-				entityliving.motionX *= (1.133f + 0.03 * this.getAmplifier());
-				entityliving.motionZ *= (1.133f + 0.03 * this.getAmplifier());
-
-				if (entityliving.motionY > 0){
-					entityliving.motionY *= 1.134;
-				}
-			}
-		}
 	}
 
 	@Override


### PR DESCRIPTION
performEffect() is only called server side (worldObj.isRemote == false), however the server doesn't know the players speed, so multiplying it doesn't work. The event listener runs on both sides, so putting the code there makes it work.